### PR TITLE
The brand picker and the actual brand can become off-sync if the brand is changed from another tab

### DIFF
--- a/storybook/addons/brand-picker/brand-picker-docs-widget.jsx
+++ b/storybook/addons/brand-picker/brand-picker-docs-widget.jsx
@@ -15,7 +15,6 @@ export function BrandPickerDocsWidget() {
     };
 
     const handleSelectBrand = brand => {
-        applyBrand(brand);
         setCurrentBrand(brand);
     };
 

--- a/storybook/addons/brand-picker/brand-picker-docs-widget.jsx
+++ b/storybook/addons/brand-picker/brand-picker-docs-widget.jsx
@@ -1,8 +1,10 @@
 import { BRANDS, useStorage } from "../../brands";
 import { COLORS_WEIGHT, getBrandColorVariableName, getPrimaryColorVariableName } from "./brands";
+import { useEffect, useRef } from "react";
 
 export function BrandPickerDocsWidget() {
     const [currentBrand, setCurrentBrand] = useStorage();
+    const previousBrand = useRef(currentBrand);
 
     const applyBrand = brand => {
         const computedStyle = window.getComputedStyle(document.documentElement);
@@ -16,6 +18,13 @@ export function BrandPickerDocsWidget() {
         applyBrand(brand);
         setCurrentBrand(brand);
     };
+
+    useEffect(() => {
+        if(previousBrand.current && previousBrand.current.id !== currentBrand.id) {
+            applyBrand(currentBrand);
+            previousBrand.current = currentBrand;
+        }
+    }, [currentBrand])
 
     return (
         <ul className="flex flex-row justify-end list pl0 mb7 mt8">

--- a/storybook/addons/brand-picker/brand-picker-docs-widget.jsx
+++ b/storybook/addons/brand-picker/brand-picker-docs-widget.jsx
@@ -19,11 +19,11 @@ export function BrandPickerDocsWidget() {
     };
 
     useEffect(() => {
-        if(previousBrand.current && previousBrand.current.id !== currentBrand.id) {
+        if( previousBrand.current && previousBrand.current.id !== currentBrand.id ) {
             applyBrand(currentBrand);
             previousBrand.current = currentBrand;
         }
-    }, [currentBrand])
+    }, [currentBrand]);
 
     return (
         <ul className="flex flex-row justify-end list pl0 mb7 mt8">


### PR DESCRIPTION
## Issue
The brand picker and the actual brand can become off-sync if the brand is changed from another tab.
![image](https://user-images.githubusercontent.com/38871812/70923062-3ed7cc80-1ff5-11ea-8441-34881132223a.png)

## What I did

Modified the BrandPickerDocsWidget to react to changes from the local storage. I made sure that the brand wasn't applied on the first mount since we don't want to overwrite css variables with the values that we're already applied.

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need an update to the documentation? No

