### PR TITLE
Use stylelint autofix instead of prettier and enforce consistant linebreaks for style and js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,8 @@ module.exports = {
         es6: true,
         node: true,
         "jest/globals": true
+    },
+    rules: {
+        "linebreak-style": ["warn", "unix"]
     }
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,9 +1,1 @@
-/.vscode
-/packages/semantic-ui-theme/semantic
-node_modules
-.eslintrc.js
-.editorconfig
-*.md
-*.mdx
-*.js
-*.jsx
+*

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,0 @@
-module.exports = {
-    tabWidth: 4,
-    printWidth: 300
-};

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,6 +1,22 @@
 module.exports = {
     extends: "@sharegate/stylelint-config-recommended",
     rules: {
-        "declaration-block-trailing-semicolon": null
+        "indentation": 4,
+        "linebreaks": "unix",
+        "max-empty-lines": [1, { ignore: ["comments"] }],
+        "no-empty-first-line": true,
+        "declaration-block-trailing-semicolon": null,
+        "rule-empty-line-before": ["always", { except: ["after-single-line-comment", "inside-block-and-after-rule", "first-nested"] }],
+        "block-opening-brace-newline-after": "always",
+        "block-closing-brace-newline-before": "always",
+        // "block-opening-brace-newline-before": "never-multi-line",
+        // "block-opening-brace-space-before": "always",
+        "declaration-bang-space-before": "always",
+        "declaration-colon-space-after": "always",
+        "declaration-empty-line-before": "never",
+        "property-case": "lower",
+        "unit-case": "lower",
+        "string-quotes": "double",
+        "font-weight-notation": "numeric"
     }
 };

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
         "editorconfig.editorconfig",
         "dbaeumer.vscode-eslint",
         "blanu.vscode-styled-jsx",
-        "thibaudcolas.stylelint",
+        "hex-ci.stylelint-plus",
         "esbenp.prettier-vscode",
         "silvenon.mdx"
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,22 +5,18 @@
         "source.fixAll": true,
         "source.organizeImports": false
     },
-    // Turns on auto format on save for all files types.
-    // This is also required to allow Prettier to auto format files on save.
     "editor.formatOnSave": true,
     "[html]": {
         "editor.formatOnSave": false
     },
-    // Turns it off for JavaScript since we use Prettier to auto format on save.
     "javascript.format.enable": false,
     "javascript.validate.enable": true,
     "json.format.enable": false,
     "css.validate": false,
-    // Required to allow auto format on save with ESLint.
     "eslint.alwaysShowStatus": true,
     "eslint.packageManager": "yarn",
     "eslint.validate": [ "javascript", "javascriptreact", "mdx" ],
-    "prettier.stylelintIntegration": true,
+    "stylelint.autoFixOnSave": true,
     "files.associations": {
         ".overrides": "less",
         ".variables": "less"

--- a/packages/css-normalize/src/normalize.css
+++ b/packages/css-normalize/src/normalize.css
@@ -94,6 +94,7 @@ abbr[title] {
 
 b,
 strong {
+    /* stylelint-disable-next-line */
     font-weight: bolder;
 }
 


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing documentation
https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
-->

Issue: https://github.com/gsoft-inc/sg-orbit/issues/39 https://github.com/gsoft-inc/sg-orbit/issues/36

## What I did

- Removed prettier vscode plugin
- Switche stylelint vscode plugin for https://marketplace.visualstudio.com/items?itemName=hex-ci.stylelint-plus
- Fine tune styleconfig config
- Add eslint linebreak rule to enforce unix linebreak

## How to test

- Is this testable with Jest or Chromatic screenshots? No
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.
