### PR TITLE
Fix intermittent failing Jest tests

### DIFF
--- a/packages/react-components/components/popup/src/popup.jsx
+++ b/packages/react-components/components/popup/src/popup.jsx
@@ -380,14 +380,18 @@ export class Popup extends AutoControlledPureComponent {
     handleDocumentBlur = () => {
         setTimeout(() => {
             if (document.activeElement.nodeName === "BODY") {
+                if (!isNil(this._containerRef.current)) {
                 // Chrome, Edge
-                this._containerRef.current.focus();
+                    this._containerRef.current.focus();
+                }
             } else {
                 // Firefox dont switch focus to body, it keeps it on the disabled element and ont trigger a proper blur event when another element is focused.
                 // That's an ugly hack to fix this.
                 setTimeout(() => {
                     if (document.activeElement.disabled) {
-                        this._containerRef.current.focus();
+                        if (!isNil(this._containerRef.current)) {
+                            this._containerRef.current.focus();
+                        }
                     }
                 }, 100);
             }


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing documentation
https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
-->

## What I did

- Added a null check in the popup component before using the containerRef since it's in a setTimeout.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
