### PR TITLE
css for checkbox

### DIFF
--- a/packages/semantic-ui-theme/semantic/src/themes/sharegate/modules/checkbox.overrides
+++ b/packages/semantic-ui-theme/semantic/src/themes/sharegate/modules/checkbox.overrides
@@ -3,7 +3,6 @@
 *******************************/
 
 /* border-box is necessary in order for the radio to be centered everywhere */
-
 .ui.radio.checkbox label:before {
     box-sizing: border-box;
     border: 2px solid var(--cloud-100);
@@ -50,8 +49,23 @@
 
 .ui.checkbox .box:before,
 .ui.checkbox label:before {
-  top: 50%;
-  transform: translateY(-50%);
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+/* Fitted checkbox should not be centered */
+.ui.checkbox.fitted .box:before,
+.ui.checkbox.fitted label:before {
+    top: 0;
+    transform: none;
+}
+
+.ui.checkbox.fitted:not(.radio):not(.toggle) input:checked ~ .box:after,
+.ui.checkbox.fitted:not(.radio):not(.toggle) input:checked ~ label:after,
+.ui.checkbox.fitted:not(.radio):not(.toggle) input:checked:focus ~ .box:after,
+.ui.checkbox.fitted:not(.radio):not(.toggle) input:checked:focus ~ label:after {
+    top: 0;
+    transform: none;
 }
 
 .ui.checkbox input:checked:disabled ~ .box:before,
@@ -127,8 +141,8 @@
 
 .ui.checkbox .box,
 .ui.checkbox label {
-  display: flex;
-  align-items: center;
+    display: flex;
+    align-items: center;
 }
 
 .ui.checkbox .box:hover::before,

--- a/packages/semantic-ui-theme/semantic/src/themes/sharegate/modules/checkbox.overrides
+++ b/packages/semantic-ui-theme/semantic/src/themes/sharegate/modules/checkbox.overrides
@@ -75,37 +75,38 @@
     background-size: 24px 24px;
 }
 
-.ui.checkbox input:indeterminate:focus ~ .box:before, .ui.checkbox input:indeterminate:focus ~ label:before {
-    background: @white url("~@orbit-ui/icons/dist/icon-check-24.svg") center center no-repeat;
-    background-size: 24px 24px;
-}
-
-.ui.checkbox input:checked:focus ~ .box:before, .ui.checkbox input:checked:focus ~ label:before {
-    background-color: @primary500;
-}
-
-.ui.checkbox.indeterminate input:not([type=radio]) ~ .box:before,
-.ui.checkbox.indeterminate input:not([type=radio]) ~ label:before {
-    background: @primary500 url("@{iconsPath}/icon-bar-white.svg") center center no-repeat;
-    background-size: 8px 8px;
-}
-
-.ui.checkbox.indeterminate input:disabled ~ .box:before, .ui.checkbox.indeterminate input:disabled ~ label:before {
-    background: var(--cloud-50);
-    border: 1px solid var(--cloud-100);
-
-}
-
-.ui.checkbox.indeterminate.checked input:disabled ~ .box:before, .ui.checkbox.indeterminate.checked input:disabled ~ label:before {
+/* Indeterminate */
+/* State / Disabled */
+.ui.checkbox.indeterminate.checked input:disabled ~ .box:before,
+.ui.checkbox.indeterminate.checked input:disabled ~ label:before {
     background: @primary100 url("@{iconsPath}/icon-bar-white.svg") center center no-repeat;
     border-color: @primary100;
     background-size: 8px 8px;
 }
 
+.ui.checkbox.indeterminate input:disabled ~ .box:before,
+.ui.checkbox.indeterminate input:disabled ~ label:before {
+    background: var(--cloud-50);
+    border: 1px solid var(--cloud-100);
+}
+
+.ui.checkbox.indeterminate:not(.radio):not(.toggle) input:checked ~ .box::after,
+.ui.checkbox.indeterminate:not(.radio):not(.toggle) input:checked ~ label::after,
+.ui.checkbox.indeterminate:not(.radio):not(.toggle) input:checked:focus ~ .box::after,
+.ui.checkbox.indeterminate:not(.radio):not(.toggle) input:checked:focus ~ label::after,
+.ui.checkbox.indeterminate:not(.radio):not(.toggle) input ~ .box::after,
+.ui.checkbox.indeterminate:not(.radio):not(.toggle) input ~ label::after,
+.ui.checkbox.indeterminate:not(.radio):not(.toggle) input:focus ~ .box::after,
+.ui.checkbox.indeterminate:not(.radio):not(.toggle) input:focus ~ label::after {
+    mask: url("@{iconsPath}/icon-bar-white.svg") center center no-repeat;
+    mask-size: 8px 8px;
+    content: '';
+    background-color: @white;
+}
+
 /* Toggle
 /***********/
 /* Semantic wants a very high toggle but we don't, let's position this */
-
 .ui.toggle.checkbox .box:after,
 .ui.toggle.checkbox label:after {
     top: 3px;

--- a/storybook/stories/semantic-ui/react/checkbox/checkbox.stories.mdx
+++ b/storybook/stories/semantic-ui/react/checkbox/checkbox.stories.mdx
@@ -46,7 +46,7 @@ A checkbox can be indeterminate.
 
 <Preview>
     <Story name="indeterminate">
-        <Checkbox defaultIndeterminate label="Milky Way" />
+        <Checkbox defaultIndeterminate label="Supernova" />
     </Story>
 </Preview>
 

--- a/storybook/stories/semantic-ui/theme/checkbox.chroma.jsx
+++ b/storybook/stories/semantic-ui/theme/checkbox.chroma.jsx
@@ -38,5 +38,17 @@ stories()
                      <Checkbox radio disabled label="Meteor Shower" />
                      <Checkbox radio checked disabled label="Meteor Shower" />
                  </div>
+                 <div className="flex">
+                     <Checkbox />
+                     <Checkbox checked />
+                     <Checkbox disabled />
+                     <Checkbox checked disabled />
+                 </div>
+                 <div className="flex">
+                     <Checkbox radio />
+                     <Checkbox radio checked />
+                     <Checkbox radio disabled />
+                     <Checkbox radio checked disabled />
+                 </div>
              </>
     );


### PR DESCRIPTION
Issue:
https://github.com/gsoft-inc/sg-orbit/issues/161

## What I did

When no label is present in a checkbox semantic adds a class of fitted. I'm taking advantage or this and remove the centering of the checkbox in this situation.

How to test : 
Visit Storybook Doc in Checkbox