### PR TITLE
Issue #192: Changed the DatePickerTextboxInput's min-width 

### DIFF
--- a/packages/react-components/components/date-picker/src/date-picker-textbox-input.jsx
+++ b/packages/react-components/components/date-picker/src/date-picker-textbox-input.jsx
@@ -225,7 +225,7 @@ export class DatePickerTextboxInput extends PureComponent {
 
             <style jsx>{`
                 .input {
-                    min-width: 350px;
+                    min-width: 300px;
                 }
 
                 .input:not("disabled") {


### PR DESCRIPTION


##Issue:
#192 

## What I did
Changed  the DatePickerTextboxInput's min-width to 300px so it's standard with the other inputs

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.
