### PR TITLE
[208] fix typ0 that prevent apricot fill style from being consumed

### DIFF
--- a/packages/tachyons/src/products/apricot/index.css
+++ b/packages/tachyons/src/products/apricot/index.css
@@ -1,4 +1,4 @@
-@import "./_background.css";
-@import "./_text.css";
+@import "./_fill.css";
 @import "./_border.css";
+@import "./_background.css";
 @import "./_text.css";

--- a/packages/tachyons/src/products/desktop/index.css
+++ b/packages/tachyons/src/products/desktop/index.css
@@ -1,4 +1,4 @@
-@import "./_fill";
-@import "./_border";
-@import "./_background";
-@import "./_text";
+@import "./_fill.css";
+@import "./_border.css";
+@import "./_background.css";
+@import "./_text.css";


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing documentation
https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
-->

Issue:

## What I did
Fix the typo that prevent apricot fill style from being consumed

## How to test

- Go to the Chromatic test of the icon react component and apply  fill-apricot-900 instead of sunray.
- Make sure that the color change for the Apricot one.
