### PR TITLE
Support ref for hoc icons

### DIFF
--- a/packages/react-components/components/dropdown/src/dropdown.jsx
+++ b/packages/react-components/components/dropdown/src/dropdown.jsx
@@ -23,7 +23,6 @@ const ACTION_SHAPE = {
     className: string
 };
 
-
 const propTypes = {
     /**
      * A dropdown can vary in sizes.

--- a/packages/react-components/components/icons/src/factories.js
+++ b/packages/react-components/components/icons/src/factories.js
@@ -1,13 +1,23 @@
 import { ArgumentError } from "@orbit-ui/react-components-shared";
 import { cloneElement } from "react";
 import { getIconSizeForControl } from "./sizes";
+import { isForwardRef } from "react-is";
 import { isFunction } from "lodash";
 
-function ensureIsKnownIconWrapper(icon) {
-    if (isFunction(icon.type)) {
-        const asString = icon.type.toString();
+function isFunctionCreatingAnIconElement(fct) {
+    const asString = fct.toString();
 
-        if (asString.includes("Icon") || asString.includes("MultiVariantIcon")) {
+    return asString.includes("Icon") || asString.includes("MultiVariantIcon");
+}
+
+function ensureIsKnownIconWrapper(icon) {
+    if (isForwardRef(icon)) {
+        if (isFunctionCreatingAnIconElement(icon.type.render)) {
+            return true;
+        }
+    }
+    else if (isFunction(icon.type)) {
+        if (isFunctionCreatingAnIconElement(icon.type)) {
             return true;
         }
     }

--- a/packages/react-components/components/icons/src/factories.js
+++ b/packages/react-components/components/icons/src/factories.js
@@ -7,7 +7,14 @@ import { isFunction } from "lodash";
 function isFunctionCreatingAnIconElement(fct) {
     const asString = fct.toString();
 
-    return asString.includes("Icon") || asString.includes("MultiVariantIcon");
+    return asString.includes("createElement(Icon") ||
+           asString.includes(".Icon") ||
+           asString.includes("createElement(PureIcon") ||
+           asString.includes(".PureIcon") ||
+           asString.includes("createElement(MultiVariantIcon") ||
+           asString.includes(".MultiVariantIcon") ||
+           asString.includes("createElement(PureMultiVariantIcon") ||
+           asString.includes(".PureMultiVariantIcon");
 }
 
 function ensureIsKnownIconWrapper(icon) {

--- a/packages/react-components/components/icons/src/icon.jsx
+++ b/packages/react-components/components/icons/src/icon.jsx
@@ -51,11 +51,15 @@ export const Icon = forwardRef((props, ref) => (
     <PureIcon { ...props } forwardedRef={ref} />
 ));
 
-Icon.create = type => {
-    return props => {
-        return <Icon type={type} {...props} />;
-    };
-};
+function createIcon(type) {
+    return forwardRef((props, ref) => <Icon type={type} ref={ref} {...props} />);
+}
+
+[PureIcon, Icon].forEach(x => {
+    x.create = createIcon;
+});
+
+//////////////////////////////////////////////
 
 export function PureMultiVariantIcon({ type24: Component24, type32: Component32, size, forwardedRef, ...rest }) {
     let type = Component32;
@@ -90,8 +94,10 @@ export const MultiVariantIcon = forwardRef((props, ref) => (
     <PureMultiVariantIcon { ...props } forwardedRef={ref} />
 ));
 
-MultiVariantIcon.create = (type24, type32) => {
-    return props => {
-        return <MultiVariantIcon type24={type24} type32={type32} {...props} />;
-    };
-};
+function createMultiVariant(type24, type32) {
+    return forwardRef((props, ref) => <MultiVariantIcon type24={type24} type32={type32} ref={ref} {...props} />);
+}
+
+[PureMultiVariantIcon, MultiVariantIcon].forEach(x => {
+    x.create = createMultiVariant;
+});

--- a/packages/react-components/components/icons/stories/icon.stories.mdx
+++ b/packages/react-components/components/icons/stories/icon.stories.mdx
@@ -200,3 +200,25 @@ A multi variants icon support the same props as `<Icon />`.
 >
     <RefLogger component={<Icon type={AzureIcon32} />} />
 </Story>
+
+export const HocAzureIcon32 = Icon.create(AzureIcon32);
+
+<Story
+    name="hoc icon ref"
+    parameters={paramsBuilder()
+        .excludeFromDocs()
+        .build()}
+>
+    <RefLogger component={<HocAzureIcon32 />} />
+</Story>
+
+export const HocFilterIcon = MultiVariantIcon.create(FilterIcon24, FilterIcon32);
+
+<Story
+    name="hoc multi-variants ref"
+    parameters={paramsBuilder()
+        .excludeFromDocs()
+        .build()}
+>
+    <RefLogger component={<HocFilterIcon />} />
+</Story>

--- a/packages/react-components/components/icons/tests/jest/factories.test.jsx
+++ b/packages/react-components/components/icons/tests/jest/factories.test.jsx
@@ -1,0 +1,49 @@
+import { AzureIcon32, FilterIcon24, FilterIcon32 } from "./assets";
+import { Icon, MultiVariantIcon } from "@orbit-ui/react-icons/src";
+import { MEDIUM } from "@orbit-ui/react-components-shared";
+import { createIconForControl } from "../../src/factories";
+import { isElement } from "react-is";
+
+test("throw when is not a known wrapper", () => {
+    function MyWrapper() {
+        return "Hello world!";
+    }
+
+    expect(() => createIconForControl(<MyWrapper />, MEDIUM)).toThrowError(/Unknown icon wrapper/);
+});
+
+test("support Icon", () => {
+    const icon = createIconForControl(<Icon type={AzureIcon32} />, MEDIUM);
+
+    expect(isElement(icon)).toBeTruthy();
+});
+
+test("support MultiVariantIcon", () => {
+    const icon = createIconForControl(<MultiVariantIcon type24={FilterIcon24} type32={FilterIcon32} />, MEDIUM);
+
+    expect(isElement(icon)).toBeTruthy();
+});
+
+test("support Icon.create", () => {
+    const HocIcon = Icon.create(AzureIcon32);
+    const icon = createIconForControl(<HocIcon />, MEDIUM);
+
+    expect(isElement(icon)).toBeTruthy();
+});
+
+test("support MultiVariantIcon.create", () => {
+    const HocIcon = MultiVariantIcon.create(FilterIcon24, FilterIcon32);
+    const icon = createIconForControl(<HocIcon />, MEDIUM);
+
+    expect(isElement(icon)).toBeTruthy();
+});
+
+test("support composition", () => {
+    function MyWrapper(props) {
+        return <Icon type={AzureIcon32} {...props} />;
+    }
+
+    const icon = createIconForControl(<MyWrapper />, MEDIUM);
+
+    expect(isElement(icon)).toBeTruthy();
+});

--- a/packages/react-components/components/icons/tests/jest/icon.test.jsx
+++ b/packages/react-components/components/icons/tests/jest/icon.test.jsx
@@ -38,3 +38,23 @@ test("ref is a DOM element", async () => {
     expect(refNode instanceof SVGElement).toBeTruthy();
     expect(refNode.tagName.toUpperCase()).toBe("SVG");
 });
+
+test("hoc icon ref is a DOM element", async () => {
+    let refNode = null;
+
+    const HocIcon = Icon.create(AzureIcon32);
+
+    render(
+        <HocIcon
+            ref={node => {
+                refNode = node;
+            }}
+        />
+    );
+
+    await wait();
+
+    expect(refNode).not.toBeNull();
+    expect(refNode instanceof SVGElement).toBeTruthy();
+    expect(refNode.tagName.toUpperCase()).toBe("SVG");
+});

--- a/packages/react-components/components/icons/tests/jest/multi-variant-icon.test.jsx
+++ b/packages/react-components/components/icons/tests/jest/multi-variant-icon.test.jsx
@@ -37,3 +37,23 @@ test("ref is a DOM element", async () => {
     expect(refNode instanceof SVGElement).toBeTruthy();
     expect(refNode.tagName.toUpperCase()).toBe("SVG");
 });
+
+test("hoc icon ref is a DOM element", async () => {
+    let refNode = null;
+
+    const HocIcon = MultiVariantIcon.create(FilterIcon24, FilterIcon32);
+
+    render(
+        <HocIcon
+            ref={node => {
+                refNode = node;
+            }}
+        />
+    );
+
+    await wait();
+
+    expect(refNode).not.toBeNull();
+    expect(refNode instanceof SVGElement).toBeTruthy();
+    expect(refNode.tagName.toUpperCase()).toBe("SVG");
+});

--- a/packages/react-components/tests/exports.test.js
+++ b/packages/react-components/tests/exports.test.js
@@ -1,5 +1,5 @@
-const fs = require("fs");
-const path = require("path");
+import fs from "fs";
+import path from "path";
 
 const IGNORE_LIST = [
     "shared"

--- a/storybook/stories/materials/shadows/stories/shadows.stories.mdx
+++ b/storybook/stories/materials/shadows/stories/shadows.stories.mdx
@@ -14,6 +14,8 @@ import Installation from "../../installation.mdx";
 
 # Shadows
 
+Shadows are used to make content appear elevated.
+
 ## Installation
 
 <Installation />

--- a/storybook/stories/semantic-ui/react/message/message.stories.mdx
+++ b/storybook/stories/semantic-ui/react/message/message.stories.mdx
@@ -194,7 +194,7 @@ A message can have two columns.
 
 A message can vary in size.
 
-Available sizes are `"small"` and `"medium"`.
+Can be set to: `"small"`, or omitted.
 
 <Preview>
     <Story name="size">


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing documentation
https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
-->

Issue: https://github.com/gsoft-inc/sg-orbit/issues/224

## What I did

- Added `forwardRef` to `Icon.create` and `MultiVariantIcon.create`
- Rework `ensureIsKnownIconWrapper` to allow forwardRef
- Added a bunch of Jest tests
- Added SB stories to tests hoc icons ref
