### PR TITLE
support for number input icon and removal of arrows

### DIFF
--- a/packages/react-components/src/number-input/src/number-input.jsx
+++ b/packages/react-components/src/number-input/src/number-input.jsx
@@ -90,7 +90,7 @@ export function InnerNumberInput(props) {
             {...rest}
             type="number"
             icon={icon}
-            iconPosition={!isNil(icon) || !isNil(loading) ? iconPosition : "undefined"}
+            iconPosition={!isNil(icon) || !isNil(loading) ? iconPosition : undefined}
             loading={loading}
             ref={forwardedRef}
             __componentName="@orbit-ui/react-components/number-input"

--- a/packages/react-components/src/number-input/src/number-input.jsx
+++ b/packages/react-components/src/number-input/src/number-input.jsx
@@ -1,5 +1,5 @@
 import { INPUT_UNSUPPORTED_PROPS, Input } from "../../input";
-import { bool, element, number, object, oneOf, string } from "prop-types";
+import { bool, element, number, object, oneOf, oneOfType, string } from "prop-types";
 import { forwardRef } from "react";
 import { isNil } from "lodash";
 import { throwWhenUnsupportedPropIsProvided } from "../../shared";
@@ -8,7 +8,7 @@ import { throwWhenUnsupportedPropIsProvided } from "../../shared";
 const SIZES = ["small", "medium", "large"];
 const DEFAULT_SIZE = "medium";
 
-const UNSUPPORTED_PROPS = [...INPUT_UNSUPPORTED_PROPS, "button", "iconsPosition", "type"];
+const UNSUPPORTED_PROPS = [...INPUT_UNSUPPORTED_PROPS, "iconsPosition", "type"];
 
 // Duplicated here until https://github.com/reactjs/react-docgen/pull/352 is merged.
 const INPUT_PROP_TYPES = {
@@ -28,6 +28,10 @@ const INPUT_PROP_TYPES = {
      * An icon can appear on the left or right.
      */
     iconPosition: oneOf(["left"]),
+    /**
+     * [Shorthand](/?path=/docs/getting-started-shorthand-props--page) to display a [button](/?path=/docs/components-button--default-story) after the value.
+     */
+    button: oneOfType([element, object]),
     /**
      * An input can vary in sizes.
      */
@@ -77,7 +81,7 @@ const defaultProps = {
 };
 
 export function InnerNumberInput(props) {
-    const { icon, loading, forwardedRef, ...rest } = props;
+    const { icon, iconPosition, loading, forwardedRef, ...rest } = props;
 
     throwWhenUnsupportedPropIsProvided(props, UNSUPPORTED_PROPS, "@orbit-ui/react-components/number-input");
 
@@ -86,7 +90,7 @@ export function InnerNumberInput(props) {
             {...rest}
             type="number"
             icon={icon}
-            iconPosition={!isNil(icon) || !isNil(loading) ? "left" : undefined}
+            iconPosition={!isNil(icon) || !isNil(loading) ? iconPosition : "undefined"}
             loading={loading}
             ref={forwardedRef}
             __componentName="@orbit-ui/react-components/number-input"

--- a/packages/react-components/src/number-input/stories/number-input.stories.mdx
+++ b/packages/react-components/src/number-input/stories/number-input.stories.mdx
@@ -131,7 +131,7 @@ A number input can be formatted with an [icon](?path=/docs/materials-icons--page
 
 ### Button
 
-A text input can contain a [button](?path=/docs/components-button--default-story). Specify the button to use with a [shorthand value](?path=/docs/getting-started-shorthand-props--page).
+A number input can contain a [button](?path=/docs/components-button--default-story). Specify the button to use with a [shorthand value](?path=/docs/getting-started-shorthand-props--page).
 
 <Preview>
     <Story name="button">

--- a/packages/react-components/src/number-input/stories/number-input.stories.mdx
+++ b/packages/react-components/src/number-input/stories/number-input.stories.mdx
@@ -1,4 +1,5 @@
-import { EditIcon } from "@react-components/icons";
+import { Button } from "@react-components/button";
+import { CloseIcon, EditIcon } from "@react-components/icons";
 import { HocWarning, InstallReactComponents, Props, ReactComponentsLayout } from "@blocks";
 import { InnerNumberInput, NumberInput } from "@react-components/number-input";
 import { Meta, Preview, Story } from "@storybook/addon-docs/blocks";
@@ -111,6 +112,7 @@ A number input can be formatted with an [icon](?path=/docs/materials-icons--page
     <Story name="icon">
         <div className="flex items-space-between">
             <NumberInput icon={<EditIcon />} placeholder="Amount" />
+            <NumberInput icon={<EditIcon />} placeholder="Amount" iconPosition="left"/>
         </div>
     </Story>
 </Preview>
@@ -121,7 +123,29 @@ A number input can be formatted with an [icon](?path=/docs/materials-icons--page
         .excludeFromDocs()
         .build()}
 >
-    <NumberInput icon={<EditIcon />} loading />
+    <div className="flex items-space-between">
+        <NumberInput icon={<EditIcon />} loading />
+        <NumberInput icon={<EditIcon />} loading iconPosition="left"/>
+    </div>
+</Story>
+
+### Button
+
+A text input can contain a [button](?path=/docs/components-button--default-story). Specify the button to use with a [shorthand value](?path=/docs/getting-started-shorthand-props--page).
+
+<Preview>
+    <Story name="button">
+        <NumberInput button={<Button icon={<CloseIcon />} />} placeholder="Amount" />
+    </Story>
+</Preview>
+
+<Story
+    name="button & loading"
+    parameters={paramsBuilder()
+        .excludeFromDocs()
+        .build()}
+>
+    <NumberInput button={<Button icon={<CloseIcon />} />} placeholder="Amount" loading />
 </Story>
 
 ### Loading

--- a/packages/react-components/src/number-input/tests/chromatic/number-input.chroma.jsx
+++ b/packages/react-components/src/number-input/tests/chromatic/number-input.chroma.jsx
@@ -27,8 +27,8 @@ stories()
         <NumberInput defaultValue={10.999} />
     )
     .add("icon", () =>
-        <div className="flex flex-column">
-            <NumberInput icon={<EditIcon />} />
+        <div className="flex">
+            <NumberInput icon={<EditIcon />} className="mr5" />
             <NumberInput icon={<EditIcon />} iconPosition="left" />
         </div>
     )
@@ -36,9 +36,9 @@ stories()
         <NumberInput button={<Button icon={<CloseIcon />} />} />
     )
     .add("loading", () =>
-        <div className="flex flex-column">
-            <NumberInput loading />
-            <NumberInput loading icon={<EditIcon />} />
-            <NumberInput loading icon={<EditIcon />} iconPosition="left" />
+        <div className="flex">
+            <NumberInput loading className="mr5" />
+            <NumberInput loading icon={<EditIcon />} className="mr5" />
+            <NumberInput loading icon={<EditIcon />} iconPosition="left" className="mr5" />
         </div>
     );

--- a/packages/react-components/src/number-input/tests/chromatic/number-input.chroma.jsx
+++ b/packages/react-components/src/number-input/tests/chromatic/number-input.chroma.jsx
@@ -1,4 +1,5 @@
-import { EditIcon } from "@react-components/icons";
+import { Button } from "@react-components/button";
+import { CloseIcon, EditIcon } from "@react-components/icons";
 import { NumberInput } from "@react-components/number-input";
 import { createChromaticSection, paramsBuilder, storiesOfBuilder } from "@utils";
 
@@ -26,8 +27,18 @@ stories()
         <NumberInput defaultValue={10.999} />
     )
     .add("icon", () =>
-        <NumberInput icon={<EditIcon />} />
+        <div className="flex flex-column">
+            <NumberInput icon={<EditIcon />} />
+            <NumberInput icon={<EditIcon />} iconPosition="left" />
+        </div>
+    )
+    .add("button", () =>
+        <NumberInput button={<Button icon={<CloseIcon />} />} />
     )
     .add("loading", () =>
-        <NumberInput loading />
+        <div className="flex flex-column">
+            <NumberInput loading />
+            <NumberInput loading icon={<EditIcon />} />
+            <NumberInput loading icon={<EditIcon />} iconPosition="left" />
+        </div>
     );

--- a/packages/semantic-ui-theme/semantic/src/themes/sharegate/elements/input.overrides
+++ b/packages/semantic-ui-theme/semantic/src/themes/sharegate/elements/input.overrides
@@ -194,5 +194,11 @@
 /* Number */
 .ui.input > input[type="number"] {
     min-width: 150px;
-    padding-right: 0 !important;
+    -moz-appearance: textfield;
+    margin: 0;
+}
+
+.ui.input > input[type="number"]::-webkit-outer-spin-button,
+.ui.input > input[type="number"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
 }


### PR DESCRIPTION
Issue:
[344](https://github.com/gsoft-inc/sg-orbit/issues/344)

Arrows were showing in number inputs, causing inconsistencies between browsers and 

## What I did

- Removed the arrows for all browsers
- Added support for right icon and button.
