### PR TITLE
Allow bool and number as valid proptype for SelectItem value

### DIFF
--- a/packages/react-components/src/select/src/SelectItem.jsx
+++ b/packages/react-components/src/select/src/SelectItem.jsx
@@ -1,6 +1,6 @@
 import { SelectContext } from "./SelectContext";
 import { Dropdown as SemanticDropdown } from "semantic-ui-react";
-import { arrayOf, element, oneOf, oneOfType, shape, string } from "prop-types";
+import { arrayOf, bool, element, number, oneOf, oneOfType, shape, string } from "prop-types";
 import { isNil } from "lodash";
 import { mergeClasses, throwWhenUnsupportedPropIsProvided } from "../../shared";
 import { renderAvatar } from "./renderAvatar";
@@ -22,7 +22,7 @@ const propTypes = {
     /**
      * The item value.
      */
-    value: string,
+    value: oneOfType([bool, number, string]),
     /**
      * A description to display with less emphasize.
      */

--- a/packages/react-components/src/select/stories/SelectItem.stories.mdx
+++ b/packages/react-components/src/select/stories/SelectItem.stories.mdx
@@ -175,3 +175,22 @@ A select item can be disabled.
         />
     </Story>
 </Preview>
+
+### Numbers
+
+A select item can have a number value
+
+<Preview>
+    <Story name="disabled">
+        <Select
+            placeholder="Astronaut"
+            options={[
+                selectItem("Julie Payette", 1),
+                selectItem("Chris Hadfield", 2),
+                selectItem("Jeremy Hansen", 3),
+                selectItem("Robert Thirks", 4)
+            ]}
+        />
+    </Story>
+</Preview>
+


### PR DESCRIPTION
Issue:
Semantic UI's Dropdown.Item allow for bool, number and string as valid values.

When providing a number as the value for a SelectItem in Orbit, you get a PropType warning.

The workaround right now is to cast to string and parse around the SelectItem but ideally, Orbit's Select would support for bool and number values as well as string.

## What I did
Modify the PropType of SelectItem to allow for bool and number to be passed.

We know Semantic UI DropdownItem support all 3 proptype values (https://react.semantic-ui.com/modules/dropdown/), so it should simply work.

## How to test
I _tried_ adding a story for my bug/usecase, I'm not sure if we want to include a story for this particular usecase.