### PR TITLE
Improved alert content & fix custom slot rendering

### DIFF
--- a/packages/react-components/src/alert/src/Alert.jsx
+++ b/packages/react-components/src/alert/src/Alert.jsx
@@ -4,10 +4,10 @@ import { CheckIcon, InfoIcon, NotificationIcon, WarningIcon } from "../../icons"
 import { Content } from "../../view";
 import { CrossButton } from "../../button";
 import { SlotProvider, StyleProvider, Wrap, createSizeAdapter, cssModule, mergeClasses, normalizeSize, useHasChildren, useMergedRefs } from "../../shared";
+import { Text } from "../../text";
 import { Transition } from "../../transition";
 import { any, bool, elementType, func, oneOf, oneOfType, string } from "prop-types";
 import { forwardRef } from "react";
-import { getTextClass } from "../../text";
 import { isNil } from "lodash";
 
 const propTypes = {
@@ -56,6 +56,46 @@ const buttonSize = createSizeAdapter({
     "sm": "xs",
     "md": "sm",
     "lg": "md"
+});
+
+const AlertContent = forwardRef(({
+    size,
+    as = "div",
+    children,
+    ...rest
+}, ref) => {
+    return (
+        <Text
+            size={size}
+            as={as}
+            ref={ref}
+            {...rest}
+        >
+            <StyleProvider
+                value={{
+                    text: {
+                        size: "inherit"
+                    },
+                    p: {
+                        size: "inherit"
+                    },
+                    link: {
+                        size: "inherit",
+                        underline: "dotted"
+                    },
+                    list: {
+                        size: "inherit"
+                    },
+                    heading: {
+                        size: headingSize(size),
+                        className: "o-ui-alert-title"
+                    }
+                }}
+            >
+                {children}
+            </StyleProvider>
+        </Text>
+    );
 });
 
 export function InnerAlert({
@@ -117,7 +157,9 @@ export function InnerAlert({
                         className: "o-ui-alert-icon"
                     },
                     content: {
-                        className: mergeClasses("o-ui-alert-content", getTextClass(size))
+                        size,
+                        className: "o-ui-alert-content",
+                        as: AlertContent
                     },
                     button: {
                         variant: "ghost",
@@ -127,31 +169,9 @@ export function InnerAlert({
                     }
                 }}
             >
-                <StyleProvider
-                    value={{
-                        text: {
-                            size: "inherit"
-                        },
-                        p: {
-                            size: "inherit"
-                        },
-                        link: {
-                            size: "inherit",
-                            underline: "dotted"
-                        },
-                        list: {
-                            size: "inherit"
-                        },
-                        heading: {
-                            size: headingSize(size),
-                            className: "o-ui-alert-title"
-                        }
-                    }}
-                >
-                    <Wrap as={Content}>
-                        {children}
-                    </Wrap>
-                </StyleProvider>
+                <Wrap as={Content}>
+                    {children}
+                </Wrap>
             </SlotProvider>
             {dismissMarkup}
         </Transition>

--- a/packages/react-components/src/alert/tests/chromatic/Alert.chroma.jsx
+++ b/packages/react-components/src/alert/tests/chromatic/Alert.chroma.jsx
@@ -1,4 +1,5 @@
 import { Alert, CriticalAlert, InfoAlert, SuccessAlert, WarningAlert } from "@react-components/alert";
+import { Box } from "@react-components/box";
 import { Button } from "@react-components/button";
 import { Content } from "@react-components/view";
 import { Heading } from "@react-components/heading";
@@ -16,6 +17,7 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%" })
+            .chromaticDelay(100)
             .build())
         .build();
 }
@@ -241,7 +243,7 @@ stories()
             </Alert>
         </Stack>
     )
-    .add("boxed", () =>
+    .add("contained", () =>
         <div style={{ width: "500px" }}>
             <Alert>
                 <InfoIcon />
@@ -249,11 +251,12 @@ stories()
             </Alert>
         </div>
     )
-    .add("variation without dismiss", () =>
-        <Stack>
-            <InfoAlert><strong>Scheduled launch</strong> today at 1PM. Please be cautious.</InfoAlert>
-            <InfoAlert>Scheduled launch today at 1PM. Please be cautious.</InfoAlert>
-        </Stack>
+    .add("box as content", () =>
+        <Alert>
+            <InfoIcon />
+            <Box slot="content">Scheduled launch today at 1PM.</Box>
+            <Button>Undo</Button>
+        </Alert>
     )
     .add("styling", () =>
         <Stack>
@@ -308,6 +311,9 @@ stories()
                         </Content>
                     </ElementType>
                     <ElementType onDismiss={() => {}}>
+                        A launch is scheduled today at 1PM.
+                    </ElementType>
+                    <ElementType>
                         A launch is scheduled today at 1PM.
                     </ElementType>
                     <ElementType onDismiss={() => {}}>

--- a/packages/react-components/src/box/src/Box.jsx
+++ b/packages/react-components/src/box/src/Box.jsx
@@ -1,5 +1,6 @@
 import { elementType, oneOfType, string } from "prop-types";
 import { forwardRef } from "react";
+import { mergeProps, useSlotProps } from "../../shared";
 
 const propTypes = {
     /**
@@ -12,12 +13,19 @@ const propTypes = {
     slot: string
 };
 
-export function InnerBox({
-    as: ElementType = "div",
-    children,
-    forwardedRef,
-    ...rest
-}) {
+export function InnerBox({ slot, ...props }) {
+    const [slotProps] = useSlotProps(slot);
+
+    const {
+        as: ElementType = "div",
+        children,
+        forwardedRef,
+        ...rest
+    } = mergeProps(
+        props,
+        slotProps
+    );
+
     return (
         <ElementType
             {...rest}

--- a/packages/react-components/src/button/src/Button.jsx
+++ b/packages/react-components/src/button/src/Button.jsx
@@ -66,8 +66,8 @@ const propTypes = {
     children: any.isRequired
 };
 
-export function InnerButton(props) {
-    const [slotProps] = useSlotProps(props, "button");
+export function InnerButton({ slot, ...props }) {
+    const [slotProps] = useSlotProps(slot ?? "button");
     const [formProps] = useFormButton();
     const [toolbarProps] = useToolbarProps();
 

--- a/packages/react-components/src/button/src/IconButton.jsx
+++ b/packages/react-components/src/button/src/IconButton.jsx
@@ -66,8 +66,8 @@ const propTypes = {
     children: any.isRequired
 };
 
-export function InnerIconButton(props) {
-    const [slotProps] = useSlotProps(props, "button");
+export function InnerIconButton({ slot, ...props }) {
+    const [slotProps] = useSlotProps(slot ?? "button");
     const [toolbarProps] = useToolbarProps();
 
     const {

--- a/packages/react-components/src/button/tests/chromatic/IconButton.chroma.jsx
+++ b/packages/react-components/src/button/tests/chromatic/IconButton.chroma.jsx
@@ -9,7 +9,6 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%" })
-            .chromaticDelay(100)
             .build())
         .build();
 }

--- a/packages/react-components/src/button/tests/chromatic/ToggleButton.chroma.jsx
+++ b/packages/react-components/src/button/tests/chromatic/ToggleButton.chroma.jsx
@@ -9,7 +9,6 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%" })
-            .chromaticDelay(100)
             .build())
         .build();
 }

--- a/packages/react-components/src/button/tests/chromatic/ToggleIconButton.chroma.jsx
+++ b/packages/react-components/src/button/tests/chromatic/ToggleIconButton.chroma.jsx
@@ -8,7 +8,6 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%" })
-            .chromaticDelay(100)
             .build())
         .build();
 }

--- a/packages/react-components/src/checkbox/tests/chromatic/Checkbox.chroma.jsx
+++ b/packages/react-components/src/checkbox/tests/chromatic/Checkbox.chroma.jsx
@@ -8,7 +8,6 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%" })
-            .chromaticDelay(100)
             .build())
         .build();
 }

--- a/packages/react-components/src/checkbox/tests/chromatic/CheckboxGroup.chroma.jsx
+++ b/packages/react-components/src/checkbox/tests/chromatic/CheckboxGroup.chroma.jsx
@@ -36,7 +36,6 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%" })
-            .chromaticDelay(100)
             .build())
         .build();
 }

--- a/packages/react-components/src/counter/src/Counter.jsx
+++ b/packages/react-components/src/counter/src/Counter.jsx
@@ -40,8 +40,8 @@ const propTypes = {
     children: any.isRequired
 };
 
-export function InnerCounter(props) {
-    const [slotProps] = useSlotProps(props, "counter");
+export function InnerCounter({ slot, ...props }) {
+    const [slotProps] = useSlotProps(slot ?? "counter");
 
     const {
         variant = "pill",

--- a/packages/react-components/src/counter/tests/chromatic/Counter.chroma.jsx
+++ b/packages/react-components/src/counter/tests/chromatic/Counter.chroma.jsx
@@ -7,7 +7,6 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%" })
-            .chromaticDelay(100)
             .build())
         .build();
 }

--- a/packages/react-components/src/date-picker/tests/chromatic/date-range-picker.chroma.jsx
+++ b/packages/react-components/src/date-picker/tests/chromatic/date-range-picker.chroma.jsx
@@ -18,7 +18,6 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%", height: "600px" })
-            .chromaticDelay(100)
             .chromaticPauseAnimationAtEnd()
             .build())
         .build();

--- a/packages/react-components/src/date-picker/tests/chromatic/inline-single-date-picker.chroma.jsx
+++ b/packages/react-components/src/date-picker/tests/chromatic/inline-single-date-picker.chroma.jsx
@@ -10,7 +10,6 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%", height: "600px" })
-            .chromaticDelay(100)
             .chromaticPauseAnimationAtEnd()
             .build())
         .build();

--- a/packages/react-components/src/date-picker/tests/chromatic/single-date-picker.chroma.jsx
+++ b/packages/react-components/src/date-picker/tests/chromatic/single-date-picker.chroma.jsx
@@ -16,7 +16,6 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%", height: "600px" })
-            .chromaticDelay(100)
             .chromaticPauseAnimationAtEnd()
             .build())
         .build();

--- a/packages/react-components/src/dot/src/Dot.jsx
+++ b/packages/react-components/src/dot/src/Dot.jsx
@@ -24,8 +24,8 @@ const propTypes = {
     as: oneOfType([string, elementType])
 };
 
-export function InnerDot(props) {
-    const [slotProps] = useSlotProps(props, "dot");
+export function InnerDot({ slot, ...props }) {
+    const [slotProps] = useSlotProps(slot ?? "dot");
 
     const {
         color,

--- a/packages/react-components/src/dot/tests/chromatic/Dot.chroma.jsx
+++ b/packages/react-components/src/dot/tests/chromatic/Dot.chroma.jsx
@@ -7,7 +7,6 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%" })
-            .chromaticDelay(100)
             .build())
         .build();
 }

--- a/packages/react-components/src/dropdown/tests/chromatic/Dropdown.chroma.jsx
+++ b/packages/react-components/src/dropdown/tests/chromatic/Dropdown.chroma.jsx
@@ -11,7 +11,6 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%", height: "800px" })
-            .chromaticDelay(100)
             .chromaticPauseAnimationAtEnd()
             .build())
         .build();

--- a/packages/react-components/src/icons/src/Icon.jsx
+++ b/packages/react-components/src/icons/src/Icon.jsx
@@ -20,8 +20,8 @@ const propTypes = {
     slot: string
 };
 
-export function InnerIcon(props) {
-    const [slotProps] = useSlotProps(props, "icon");
+export function InnerIcon({ slot, ...props }) {
+    const [slotProps] = useSlotProps(slot ?? "icon");
     const [styleProps] = useStyleProps("icon");
 
     const {

--- a/packages/react-components/src/icons/src/IconList.jsx
+++ b/packages/react-components/src/icons/src/IconList.jsx
@@ -18,8 +18,8 @@ const propTypes = {
     children: any.isRequired
 };
 
-export function InnerIconList(props) {
-    const [slotProps] = useSlotProps(props, "icon");
+export function InnerIconList({ slot, ...props }) {
+    const [slotProps] = useSlotProps(slot ?? "icon");
 
     const {
         size,

--- a/packages/react-components/src/icons/tests/chromatic/Icons.chroma.jsx
+++ b/packages/react-components/src/icons/tests/chromatic/Icons.chroma.jsx
@@ -140,7 +140,6 @@ import { createChromaticSection, paramsBuilder, storiesOfBuilder } from "@utils"
 function stories() {
     return storiesOfBuilder(module, createChromaticSection("Icons"))
         .parameters(paramsBuilder()
-            .chromaticDelay(100)
             .build())
         .build();
 }

--- a/packages/react-components/src/image/tests/chromatic/Image.chroma.jsx
+++ b/packages/react-components/src/image/tests/chromatic/Image.chroma.jsx
@@ -17,7 +17,7 @@ stories()
     .add("default", () =>
         <Image src={Launch} alt="SpaceX launch" />
     )
-    .add("boxed", () =>
+    .add("contained", () =>
         <div style={{ width: "200px", height: "200px" }}>
             <Image src={Launch} alt="SpaceX launch" />
         </div>

--- a/packages/react-components/src/index.js
+++ b/packages/react-components/src/index.js
@@ -19,7 +19,7 @@ export * from "./lozenge";
 export * from "./visually-hidden";
 export * from "./text";
 export * from "./paragraph";
-export * from "./Heading";
+export * from "./heading";
 export * from "./toolbar";
 export * from "./layout";
 export * from "./dot";

--- a/packages/react-components/src/input/src/TextInput.jsx
+++ b/packages/react-components/src/input/src/TextInput.jsx
@@ -115,7 +115,7 @@ export function InnerTextInput(props) {
         ...rest
     } = mergeProps(
         props,
-        omitProps(toolbarProps, ["isInToolbar", "orientation"]),
+        omitProps(toolbarProps, ["orientation"]),
         wrappedInputPropsAdapter(fieldProps)
     );
 

--- a/packages/react-components/src/input/tests/chromatic/NumberInput.chroma.jsx
+++ b/packages/react-components/src/input/tests/chromatic/NumberInput.chroma.jsx
@@ -7,7 +7,6 @@ function stories(segment) {
     return storiesOfBuilder(module, createChromaticSection("NumberInput"))
         .segment(segment)
         .parameters(paramsBuilder()
-            .chromaticDelay(100)
             .canvasLayout({ width: "80%" })
             .build())
         .build();

--- a/packages/react-components/src/input/tests/chromatic/PasswordInput.chroma.jsx
+++ b/packages/react-components/src/input/tests/chromatic/PasswordInput.chroma.jsx
@@ -6,7 +6,6 @@ function stories(segment) {
     return storiesOfBuilder(module, createChromaticSection("PasswordInput"))
         .segment(segment)
         .parameters(paramsBuilder()
-            .chromaticDelay(100)
             .canvasLayout({ width: "80%" })
             .build())
         .build();

--- a/packages/react-components/src/input/tests/chromatic/TextArea.chroma.jsx
+++ b/packages/react-components/src/input/tests/chromatic/TextArea.chroma.jsx
@@ -7,7 +7,6 @@ function stories(segment) {
     return storiesOfBuilder(module, createChromaticSection("TextArea"))
         .segment(segment)
         .parameters(paramsBuilder()
-            .chromaticDelay(100)
             .canvasLayout({ width: "80%" })
             .build())
         .build();

--- a/packages/react-components/src/input/tests/chromatic/TextInput.chroma.jsx
+++ b/packages/react-components/src/input/tests/chromatic/TextInput.chroma.jsx
@@ -7,7 +7,6 @@ function stories(segment) {
     return storiesOfBuilder(module, createChromaticSection("TextInput"))
         .segment(segment)
         .parameters(paramsBuilder()
-            .chromaticDelay(100)
             .canvasLayout({ width: "80%" })
             .build())
         .build();

--- a/packages/react-components/src/layout/tests/chromatic/Flex.chroma.jsx
+++ b/packages/react-components/src/layout/tests/chromatic/Flex.chroma.jsx
@@ -5,7 +5,6 @@ function stories(segment) {
     return storiesOfBuilder(module, createChromaticSection("Flex"))
         .segment(segment)
         .parameters(paramsBuilder()
-            .chromaticDelay(100)
             .canvasLayout({ width: "80%" })
             .build())
         .build();

--- a/packages/react-components/src/link/src/TextLink.jsx
+++ b/packages/react-components/src/link/src/TextLink.jsx
@@ -99,16 +99,20 @@ export function InnerTextLink(props) {
         forwardedRef
     });
 
-    const content = external
-        ? (
+    let content = (
+        <Wrap as={Text}>
+            {children}
+        </Wrap>
+    );
+
+    if (external) {
+        content = (
             <>
-                <Wrap as={Text}>
-                    {children}
-                </Wrap>
+                {content}
                 <ArrowIcon />
             </>
-        )
-        : children;
+        );
+    }
 
     return (
         <ElementType

--- a/packages/react-components/src/lozenge/tests/chromatic/Lozenge.chroma.jsx
+++ b/packages/react-components/src/lozenge/tests/chromatic/Lozenge.chroma.jsx
@@ -9,7 +9,6 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%" })
-            .chromaticDelay(100)
             .build())
         .build();
 }

--- a/packages/react-components/src/shared/src/SlotContext.js
+++ b/packages/react-components/src/shared/src/SlotContext.js
@@ -11,12 +11,10 @@ export function useSlotContext() {
     return useContext(SlotContext);
 }
 
-export function useSlotProps({ slot: slotProp }, defaultSlot) {
+export function useSlotProps(slot) {
     const context = useSlotContext();
 
     if (!isNil(context)) {
-        const slot = slotProp ?? defaultSlot;
-
         const props = !isNil(slot)
             ? context[slot] ?? {}
             : {};

--- a/packages/react-components/src/switch/tests/chromatic/Switch.chroma.jsx
+++ b/packages/react-components/src/switch/tests/chromatic/Switch.chroma.jsx
@@ -7,7 +7,6 @@ function stories(segment) {
         .segment(segment)
         .parameters(paramsBuilder()
             .canvasLayout({ width: "80%" })
-            .chromaticDelay(100)
             .build())
         .build();
 }

--- a/packages/react-components/src/text/src/Text.jsx
+++ b/packages/react-components/src/text/src/Text.jsx
@@ -29,8 +29,8 @@ const propTypes = {
     children: any.isRequired
 };
 
-export function InnerText(props) {
-    const [slotProps] = useSlotProps(props, "text");
+export function InnerText({ slot, ...props }) {
+    const [slotProps] = useSlotProps(slot ?? "text");
     const [styleProps] = useStyleProps("text");
 
     const {

--- a/packages/react-components/src/toolbar/tests/chromatic/Toolbar.chroma.jsx
+++ b/packages/react-components/src/toolbar/tests/chromatic/Toolbar.chroma.jsx
@@ -12,7 +12,6 @@ function stories(segment) {
     return storiesOfBuilder(module, createChromaticSection("Toolbar"))
         .segment(segment)
         .parameters(paramsBuilder()
-            .chromaticDelay(100)
             .canvasLayout({ width: "80%" })
             .build())
         .build();

--- a/packages/react-components/src/tooltip/tests/chromatic/Tooltip.chroma.jsx
+++ b/packages/react-components/src/tooltip/tests/chromatic/Tooltip.chroma.jsx
@@ -8,8 +8,8 @@ function stories(segment) {
     return storiesOfBuilder(module, createChromaticSection("Tooltip"))
         .segment(segment)
         .parameters(paramsBuilder()
-            .chromaticDelay(100)
             .canvasLayout({ width: "80%", paddingTop: "100px" })
+            .chromaticDelay(100)
             .build())
         .build();
 }

--- a/packages/react-components/src/view/src/Content.jsx
+++ b/packages/react-components/src/view/src/Content.jsx
@@ -17,8 +17,8 @@ const propTypes = {
     children: any.isRequired
 };
 
-export function InnerContent(props) {
-    const [slotProps] = useSlotProps(props, "content");
+export function InnerContent({ slot, ...props }) {
+    const [slotProps] = useSlotProps(slot ?? "content");
 
     const {
         as: ElementType = "div",


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing documentation
https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
-->

Issue:

## What I did

- Added a custom AlertContent container to render alert content
- When specifying a custom `slot` prop it was rendered on the root element. It's not fixed.

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
