### PR TITLE
Update TagsPicker content when the items property changes

### DIFF
--- a/packages/react-components/src/tags-picker/src/tags-picker.jsx
+++ b/packages/react-components/src/tags-picker/src/tags-picker.jsx
@@ -151,8 +151,7 @@ export class TagsPicker extends AutoControlledPureComponent {
         placeholder: "Search",
         selectedItemsComponent: <TagsPickerSelectedItems />,
         clearButton: <TagsPickerClearButton />,
-        size: DEFAULT_SIZE,
-        defaultItems: []
+        size: DEFAULT_SIZE
     };
 
     static autoControlledProps = ["values", "open", "items"];

--- a/packages/react-components/src/tags-picker/src/tags-picker.jsx
+++ b/packages/react-components/src/tags-picker/src/tags-picker.jsx
@@ -50,6 +50,10 @@ export class TagsPicker extends AutoControlledPureComponent {
          */
         items: arrayOf(shape(ITEM_SHAPE)).isRequired,
         /**
+         * Default available items.
+         */
+        defaultItems: arrayOf(shape(ITEM_SHAPE)),
+        /**
          * A controlled array of selected values.
          */
         values: arrayOf(string),
@@ -147,10 +151,11 @@ export class TagsPicker extends AutoControlledPureComponent {
         placeholder: "Search",
         selectedItemsComponent: <TagsPickerSelectedItems />,
         clearButton: <TagsPickerClearButton />,
-        size: DEFAULT_SIZE
+        size: DEFAULT_SIZE,
+        defaultItems: []
     };
 
-    static autoControlledProps = ["values", "open"];
+    static autoControlledProps = ["values", "open", "items"];
 
     // Expose sub-components.
     static Dropdown = TagsPickerDropdown;


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing documentation
https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
-->

Issue:
When the items property of TagsPicker changes the content of the dropdown is not updated

## What I did
Added items to autoControlledProps

## How to test

Create a TagsPicker and change it's items prop content with a list containing different values

- Is this testable with Jest or Chromatic screenshots? Maybe
- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.
