### PR TITLE
Added convenience aliases for Paragraph and Headings

### DIFF
--- a/packages/react-components/src/heading/docs/Heading.stories.mdx
+++ b/packages/react-components/src/heading/docs/Heading.stories.mdx
@@ -1,7 +1,6 @@
 import { ArgsTable, Meta, Story } from "@storybook/addon-docs/blocks";
 import { ComponentInfo, Preview, Tagline } from "@stories/components";
-import { Heading, InnerHeading } from "@react-components/heading";
-import { paramsBuilder } from "@stories/utils";
+import { H1, H2, H3, H4, H5, H6, Heading, InnerHeading } from "@react-components/heading";
 
 <Meta
     title="Components/Heading"
@@ -13,7 +12,7 @@ import { paramsBuilder } from "@stories/utils";
 <Tagline>Heading is used to create various levels of typographic hierarchies.</Tagline>
 
 <ComponentInfo
-    usage={"import { Heading } from \"@orbit-ui/react-components\""}
+    usage={"import { Heading, H1, H2, H3, H4, H5, H6 } from \"@orbit-ui/react-components\""}
     githubPath="/packages/react-components/src/heading/src"
 />
 
@@ -42,12 +41,29 @@ You can alter the size of the heading by specifying a `size` prop. The available
     </Story>
 </Preview>
 
+### Aliases
+
+Convience aliases are available for standard HTML headers.
+
+<Preview>
+    <Story name="aliases">
+        <>
+            <H1>Migrate, adapt, and control the cloud.</H1>
+            <H2>Migrate, adapt, and control the cloud.</H2>
+            <H3>Migrate, adapt, and control the cloud.</H3>
+            <H4>Migrate, adapt, and control the cloud.</H4>
+            <H5>Migrate, adapt, and control the cloud.</H5>
+            <H6>Migrate, adapt, and control the cloud.</H6>
+        </>
+    </Story>
+</Preview>
+
 ## API
 
 ### Heading
 
 <ComponentInfo
-    usage={"import { Heading } from \"@orbit-ui/react-components\""}
+    usage={"import { Heading, H1, H2, H3, H4, H5, H6 } from \"@orbit-ui/react-components\""}
     compact
 />
 

--- a/packages/react-components/src/heading/src/Heading.tsx
+++ b/packages/react-components/src/heading/src/Heading.tsx
@@ -61,3 +61,23 @@ export const Heading = slot("heading", forwardRef<InnerHeadingProps>((props, ref
 export type HeadingProps = ComponentProps<typeof Heading>
 
 Heading.displayName = "Heading";
+
+// Aliases
+
+function createAlias(as: ElementType, size: InnerHeadingProps["size"]) {
+    return slot("heading", forwardRef<Omit<InnerHeadingProps, "size" | "as">, typeof as>((props, ref) => (
+        <InnerHeading
+            {...props}
+            size={size}
+            as={as}
+            forwardedRef={ref}
+        />
+    )));
+}
+
+export const H1 = createAlias("h1", "xl");
+export const H2 = createAlias("h2", "lg");
+export const H3 = createAlias("h3", "md");
+export const H4 = createAlias("h4", "sm");
+export const H5 = createAlias("h5", "xs");
+export const H6 = createAlias("h6", "2xs");

--- a/packages/react-components/src/heading/tests/chromatic/Heading.chroma.jsx
+++ b/packages/react-components/src/heading/tests/chromatic/Heading.chroma.jsx
@@ -1,4 +1,4 @@
-import { Heading } from "@react-components/heading";
+import { H1, H2, H3, H4, H5, H6, Heading } from "@react-components/heading";
 import { Inline, Stack } from "@react-components/layout";
 import { storiesOfBuilder } from "@stories/utils";
 
@@ -10,13 +10,13 @@ function stories(segment) {
 
 stories()
     .add("size", () =>
-        <div>
+        <>
             <Heading as="div" size="xl">Migrate, adapt, and<br />control the cloud.</Heading>
             <Heading as="div" size="lg">Migrate, adapt, and<br />control the cloud.</Heading>
             <Heading as="div">Migrate, adapt, and<br />control the cloud.</Heading>
             <Heading as="div" size="sm">Migrate, adapt, and<br />control the cloud.</Heading>
             <Heading as="div" size="xs">Migrate, adapt, and<br />control the cloud.</Heading>
-        </div>
+        </>
     )
     .add("as header element", () =>
         <Stack>
@@ -31,4 +31,14 @@ stories()
                 <Heading as="h6">Migrate, adapt, and<br />control the cloud.</Heading>
             </Inline>
         </Stack>
+    )
+    .add("alias", () =>
+        <>
+            <H1>Migrate, adapt, and<br />control the cloud.</H1>
+            <H2>Migrate, adapt, and<br />control the cloud.</H2>
+            <H3>Migrate, adapt, and<br />control the cloud.</H3>
+            <H4>Migrate, adapt, and<br />control the cloud.</H4>
+            <H5>Migrate, adapt, and<br />control the cloud.</H5>
+            <H6>Migrate, adapt, and<br />control the cloud.</H6>
+        </>
     );

--- a/packages/react-components/src/icons/src/Icon.tsx
+++ b/packages/react-components/src/icons/src/Icon.tsx
@@ -71,11 +71,11 @@ export type IconProps = ComponentProps<typeof Icon>;
 ////////
 
 export function createIcon(type: ElementType) {
-    return slot("icon", forwardRef<Omit<InnerIconProps, "type" | "forwardedRef">, "svg">((props, ref) =>
-        <Icon
+    return slot("icon", forwardRef<Omit<InnerIconProps, "type">, "svg">((props, ref) =>
+        <InnerIcon
             {...props}
             type={type}
-            ref={ref}
+            forwardedRef={ref}
         />
     ));
 }

--- a/packages/react-components/src/icons/src/MultiVariantIcon.tsx
+++ b/packages/react-components/src/icons/src/MultiVariantIcon.tsx
@@ -53,12 +53,12 @@ export type MultiVariantIconProps = ComponentProps<typeof MultiVariantIcon>;
 ////////
 
 export function createMultiVariantIcon(type24: ElementType, type32: ElementType) {
-    return slot("icon", forwardRef<Omit<InnerMultiVariantIconProps, "type24" | "type32" | "forwardedRef">, "svg">((props, ref) =>
-        <MultiVariantIcon
+    return slot("icon", forwardRef<Omit<InnerMultiVariantIconProps, "type24" | "type32">, "svg">((props, ref) =>
+        <InnerMultiVariantIcon
             {...props}
             type24={type24}
             type32={type32}
-            ref={ref}
+            forwardedRef={ref}
         />
     ));
 }

--- a/packages/react-components/src/paragraph/docs/Paragraph.stories.mdx
+++ b/packages/react-components/src/paragraph/docs/Paragraph.stories.mdx
@@ -1,6 +1,6 @@
 import { ArgsTable, Meta, Story } from "@storybook/addon-docs/blocks";
 import { ComponentInfo, Preview, Tagline } from "@stories/components";
-import { InnerParagraph, Paragraph } from "@react-components/paragraph";
+import { InnerParagraph, P, Paragraph } from "@react-components/paragraph";
 
 <Meta
     title="Components/Paragraph"
@@ -12,7 +12,7 @@ import { InnerParagraph, Paragraph } from "@react-components/paragraph";
 <Tagline>A paragraph is used to render blocks of text.</Tagline>
 
 <ComponentInfo
-    usage={"import { Paragraph } from \"@orbit-ui/react-components\""}
+    usage={"import { Paragraph, P } from \"@orbit-ui/react-components\""}
     githubPath="/packages/react-components/src/paragraph/src"
 />
 
@@ -31,11 +31,21 @@ You can alter the size of the paragraph by specifying a `size` prop. The availab
     </Story>
 </Preview>
 
+### Alias
+
+A convenience alias is available as `<P>`.
+
+<Preview>
+    <Story name="alias">
+        <P>If two pieces of the same type of metal touch in space they will permanently bond.</P>
+    </Story>
+</Preview>
+
 ## API
 
 <ArgsTable of={InnerParagraph} />
 
 <ComponentInfo
-    usage={"import { Paragraph } from \"@orbit-ui/react-components\""}
+    usage={"import { Paragraph, P } from \"@orbit-ui/react-components\""}
     compact
 />

--- a/packages/react-components/src/paragraph/src/Paragraph.tsx
+++ b/packages/react-components/src/paragraph/src/Paragraph.tsx
@@ -79,3 +79,7 @@ export type ParagraphProps = ComponentProps<typeof Paragraph>
 
 Paragraph.displayName = "Paragraph";
 
+// Alias
+export const P = Paragraph;
+
+

--- a/packages/react-components/src/paragraph/tests/chromatic/Paragraph.chroma.jsx
+++ b/packages/react-components/src/paragraph/tests/chromatic/Paragraph.chroma.jsx
@@ -1,4 +1,4 @@
-import { Paragraph } from "@react-components/paragraph";
+import { P, Paragraph } from "@react-components/paragraph";
 import { TextLink } from "@react-components/link";
 import { storiesOfBuilder } from "@stories/utils";
 
@@ -43,5 +43,15 @@ stories()
         <div>
             <Paragraph className="bg-red">If two pieces of the same type of metal touch<br />in space they will permanently bond.</Paragraph>
             <Paragraph style={{ backgroundColor: "red" }}>If two pieces of the same type of metal touch<br />in space they will permanently bond.</Paragraph>
+        </div>
+    )
+    .add("alias", () =>
+        <div>
+            <P size="2xl">If two pieces of the same type of metal touch<br />in space they will permanently bond.</P>
+            <P size="xl">If two pieces of the same type of metal touch<br />in space they will permanently bond.</P>
+            <P size="lg">If two pieces of the same type of metal touch<br />in space they will permanently bond.</P>
+            <P>If two pieces of the same type of metal touch<br />in space they will permanently bond.</P>
+            <P size="sm">If two pieces of the same type of metal touch<br />in space they will permanently bond.</P>
+            <P size="xs">If two pieces of the same type of metal touch<br />in space they will permanently bond.</P>
         </div>
     );


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing documentation
https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
-->

Issue:

## What I did

- Added a `<P>` alias for <Paragraph>
- Added `<H1>`, `<H2>`, `<H3>`, `<H4>`, `<H5>`, `<H6>` aliases for Headings
- Icons factories now use Inner components

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
