### PR TITLE
Remove dynamic items

### DIFF
--- a/packages/react-components/src/accordion/docs/Accordion.stories.mdx
+++ b/packages/react-components/src/accordion/docs/Accordion.stories.mdx
@@ -110,12 +110,12 @@ An accordion can allow multiple items to be expanded at once.
     </Story>
 </Preview>
 
-### Array map
+### Dynamic items
 
-An accordion items can be rendered with an array map.
+An accordion items can be rendered dynamically.
 
 <Preview>
-    <Story name="data render">
+    <Story name="dynamic items">
         <Accordion aria-label="Planets">
             {[
                 { id: "mars", header: "Mars", content: "Mars is the fourth planet from the Sun and the second-smallest planet." },

--- a/packages/react-components/src/accordion/tests/chromatic/Accordion.chroma.jsx
+++ b/packages/react-components/src/accordion/tests/chromatic/Accordion.chroma.jsx
@@ -226,7 +226,7 @@ stories()
             </Item>
         </Accordion>
     )
-    .add("array map", () =>
+    .add("dynamic items", () =>
         <Stack>
             <Accordion>
                 {["1", "2", "3"].map(x => (

--- a/packages/react-components/src/autocomplete/docs/Autocomplete.stories.mdx
+++ b/packages/react-components/src/autocomplete/docs/Autocomplete.stories.mdx
@@ -254,40 +254,16 @@ An autocomplete can be part of a form. To submit the value of a select, make sur
     </Story>
 </Preview>
 
-### Array map
+### Dynamic items
 
-An autocomplete items can be rendered with an array map.
+An autocomplete items can be rendered dynamically.
 
 <Preview>
-    <Story name="array map">
+    <Story name="dynamic items">
         <Autocomplete placeholder="Planets" aria-label="Planets">
             {["Earth", "Jupiter", "Mars", "Mercury", "Neptune", "Saturn", "Uranus"].map(x => (
                 <Item key={x.toLowerCase()}>{x}</Item>
             ))}
-        </Autocomplete>
-    </Story>
-</Preview>
-
-### Dynamic items
-
-An autocomplete items can be dynamic.
-
-The item object structure can be wathever you prefer, it doesn't have to be `key` and `value`.
-
-<Preview>
-    <Story name="dynamic items">
-        <Autocomplete
-            items={[
-                { key: "earth", value: "Earth" },
-                { key: "jupiter", value: "Jupiter" },
-                { key: "mars", value: "Mars" }
-            ]}
-            placeholder="Planets"
-            aria-label="Planets"
-        >
-            {({ items }) => items.map((x => (
-                <Item key={x.key}>{x.value}</Item>
-            )))}
         </Autocomplete>
     </Story>
 </Preview>

--- a/packages/react-components/src/autocomplete/docs/RemoteItems.sample.jsx
+++ b/packages/react-components/src/autocomplete/docs/RemoteItems.sample.jsx
@@ -19,13 +19,12 @@
 
     return (
         <Autocomplete
-            items={fetcher.items}
             loading={fetcher.isLoading}
             onSearch={fetcher.search}
             placeholder="Select a country"
             aria-label="Countries"
         >
-            {({ items }) => items.map((x => (
+            {() => fetcher.items.map((x => (
                 <Item key={x.key}>{x.value}</Item>
             )))}
         </Autocomplete>

--- a/packages/react-components/src/autocomplete/src/Autocomplete.jsx
+++ b/packages/react-components/src/autocomplete/src/Autocomplete.jsx
@@ -15,7 +15,7 @@ import {
 import { Listbox, OptionKeyProp } from "../../listbox";
 import { Overlay, isDevToolsBlurEvent, isTargetParent, useFocusWithin, usePopup, useTriggerWidth } from "../../overlay";
 import { SearchInput } from "../../text-input";
-import { any, arrayOf, bool, element, elementType, func, number, object, oneOf, oneOfType, string } from "prop-types";
+import { any, bool, element, elementType, func, number, object, oneOf, oneOfType, string } from "prop-types";
 import { forwardRef, useCallback, useRef, useState } from "react";
 import { getItemText, useCollectionSearch } from "../../collection";
 import { isNil } from "lodash";
@@ -44,10 +44,6 @@ const propTypes = {
      * Temporary text that occupies the autocomplete trigger when no value is selected.
      */
     placeholder: string,
-    /**
-     * Items to render.
-     */
-    items: arrayOf(object),
     /**
      * Whether or not the autocomplete should display a loading state.
      */
@@ -155,7 +151,6 @@ export function InnerAutocomplete(props) {
         value: valueProp,
         defaultValue,
         placeholder,
-        items,
         onSearch,
         loading,
         clearOnSelect,
@@ -224,7 +219,7 @@ export function InnerAutocomplete(props) {
     const listboxRef = useRef();
     const triggerRef = useCommittedRef(triggerElement);
 
-    const [results, searchCollection] = useCollectionSearch(children, { items, onSearch });
+    const [results, searchCollection] = useCollectionSearch(children, { onSearch });
 
     const open = useCallback(event => {
         setIsOpen(event, true);

--- a/packages/react-components/src/collection/src/useCollection.ts
+++ b/packages/react-components/src/collection/src/useCollection.ts
@@ -123,14 +123,14 @@ export class CollectionBuilder {
         return parsedItem;
     }
 
-    build(children: ReactNode, { items }: Collection) {
+    build(children: ReactNode) {
         if (isNil(children)) {
             return [];
         }
 
         let index = 0;
 
-        const elements = resolveChildren(children, { items: items ?? [] });
+        const elements = resolveChildren(children);
 
         const incrementIndex = () => {
             return index++;
@@ -154,12 +154,8 @@ export class CollectionBuilder {
     }
 }
 
-export interface Collection {
-    items?: CollectionItem[];
-}
-
-export function useCollection(children: ReactNode, { items }: Collection = {}) {
+export function useCollection(children: ReactNode) {
     const builder = useMemo(() => new CollectionBuilder(), []);
 
-    return useMemo(() => builder.build(children, { items }), [builder, children, items]);
+    return useMemo(() => builder.build(children), [builder, children]);
 }

--- a/packages/react-components/src/collection/src/useCollectionSearch.js
+++ b/packages/react-components/src/collection/src/useCollectionSearch.js
@@ -32,8 +32,8 @@ function useNodeFilter(nodes) {
     return [results, filter];
 }
 
-export function useCollectionSearch(children, { items, onSearch }) {
-    const nodes = useCollection(children, { items });
+export function useCollectionSearch(children, { onSearch }) {
+    const nodes = useCollection(children);
 
     const [filterResults, filterNodes] = useNodeFilter(nodes);
 

--- a/packages/react-components/src/heading/docs/Heading.stories.mdx
+++ b/packages/react-components/src/heading/docs/Heading.stories.mdx
@@ -43,7 +43,7 @@ You can alter the size of the heading by specifying a `size` prop. The available
 
 ### Aliases
 
-Convience aliases are available for standard HTML headers.
+Convenience aliases are available for standard HTML headers.
 
 <Preview>
     <Story name="aliases">

--- a/packages/react-components/src/heading/tests/chromatic/Heading.chroma.jsx
+++ b/packages/react-components/src/heading/tests/chromatic/Heading.chroma.jsx
@@ -32,7 +32,7 @@ stories()
             </Inline>
         </Stack>
     )
-    .add("alias", () =>
+    .add("aliases", () =>
         <>
             <H1>Migrate, adapt, and<br />control the cloud.</H1>
             <H2>Migrate, adapt, and<br />control the cloud.</H2>

--- a/packages/react-components/src/menu/docs/Menu.stories.mdx
+++ b/packages/react-components/src/menu/docs/Menu.stories.mdx
@@ -300,12 +300,12 @@ You can use a [disclosure arrow](?path=/docs/disclosure-arrow--context) componen
     </Story>
 </Preview>
 
-### Array map
+### Dynamic items
 
-A menu items can be rendered with an array map.
+A menu items can be rendered dynamically.
 
 <Preview>
-    <Story name="array map">
+    <Story name="dynamic items">
         <MenuTrigger>
             <IconButton color="secondary" aria-label="View tasks">
                 <VerticalDotsIcon />
@@ -314,35 +314,6 @@ A menu items can be rendered with an array map.
                 {["Launch", "Eject", "Land", "Help", "Exit"].map(x => (
                     <Item key={x.toLowerCase()}>{x}</Item>
                 ))}
-            </Menu>
-        </MenuTrigger>
-    </Story>
-</Preview>
-
-### Dynamic items
-
-A menu items can be dynamic.
-
-The item object structure can be wathever you prefer, it doesn't have to be `key` and `value`.
-
-<Preview>
-    <Story name="dynamic items">
-        <MenuTrigger>
-            <IconButton color="secondary" aria-label="View tasks">
-                <VerticalDotsIcon />
-            </IconButton>
-            <Menu
-                items={[
-                    { key: "launch", value: "Launch..." },
-                    { key: "eject", value: "Eject..." },
-                    { key: "land", value: "Land..." },
-                    { key: "help", value: "Help" },
-                    { key: "exit", value: "Exit" }
-                ]}
-            >
-                {({ items }) => items.map((x => (
-                    <Item key={x.key}>{x.value}</Item>
-                )))}
             </Menu>
         </MenuTrigger>
     </Story>

--- a/packages/react-components/src/menu/src/Menu.jsx
+++ b/packages/react-components/src/menu/src/Menu.jsx
@@ -22,7 +22,7 @@ import { MenuItem } from "./MenuItem";
 import { MenuSection } from "./MenuSection";
 import { NodeType, useCollection } from "../../collection";
 import { SelectionMode } from "./selectionMode";
-import { any, arrayOf, bool, elementType, func, number, object, oneOf, oneOfType, string } from "prop-types";
+import { any, arrayOf, bool, elementType, func, number, oneOf, oneOfType, string } from "prop-types";
 import { forwardRef } from "react";
 import { isNil, isNumber } from "lodash";
 
@@ -48,10 +48,6 @@ const propTypes = {
      * The type of selection that is allowed.
      */
     selectionMode: oneOf(["none", "single", "multiple"]),
-    /**
-     * Items to render.
-     */
-    items: arrayOf(object),
     /**
      * Whether or not the menu should autofocus on render.
      */
@@ -80,7 +76,6 @@ export function InnerMenu({
     defaultSelectedKeys,
     onSelectionChange,
     selectionMode = "none",
-    items,
     autoFocus,
     defaultFocusTarget,
     fluid,
@@ -172,7 +167,7 @@ export function InnerMenu({
         })
     });
 
-    const nodes = useCollection(children, { items });
+    const nodes = useCollection(children);
 
     const rootId = useId(id, id ? null : "o-ui-menu");
 

--- a/packages/react-components/src/menu/tests/chromatic/Menu.chroma.jsx
+++ b/packages/react-components/src/menu/tests/chromatic/Menu.chroma.jsx
@@ -369,7 +369,7 @@ stories()
             </Menu>
         </Inline>
     )
-    .add("array map", () =>
+    .add("dynamic items", () =>
         <Menu aria-label="Planets">
             {["Earth", "Jupiter", "Mars", "Mercury", "Neptune", "Saturn", "Uranus"].map(x => (
                 <Item key={x.toLowerCase()}>{x}</Item>

--- a/packages/react-components/src/select/docs/Select.stories.mdx
+++ b/packages/react-components/src/select/docs/Select.stories.mdx
@@ -271,40 +271,16 @@ A select can be part of a form. To submit the value of a select, make sure you s
     </Story>
 </Preview>
 
-### Array map
+### Dynamic items
 
-A select items can be rendered with an array map.
+A select items can be rendered dynamically.
 
 <Preview>
-    <Story name="array map">
+    <Story name="dynamic items">
         <Select placeholder="Planets" aria-label="Planets">
             {["Earth", "Jupiter", "Mars", "Mercury", "Neptune", "Saturn", "Uranus"].map(x => (
                 <Item key={x.toLowerCase()}>{x}</Item>
             ))}
-        </Select>
-    </Story>
-</Preview>
-
-### Dynamic items
-
-A select items can be dynamic.
-
-The item object structure can be wathever you prefer, it doesn't have to be `key` and `value`.
-
-<Preview>
-    <Story name="dynamic items">
-        <Select
-            items={[
-                { key: "earth", value: "Earth" },
-                { key: "jupiter", value: "Jupiter" },
-                { key: "mars", value: "Mars" }
-            ]}
-            placeholder="Planets"
-            aria-label="Planets"
-        >
-            {({ items }) => items.map((x => (
-                <Item key={x.key}>{x.value}</Item>
-            )))}
         </Select>
     </Story>
 </Preview>

--- a/packages/react-components/src/select/src/Select.jsx
+++ b/packages/react-components/src/select/src/Select.jsx
@@ -6,7 +6,6 @@ import { Listbox } from "../../listbox";
 import { Overlay } from "../../overlay";
 import { Text } from "../../text";
 import { any, bool, element, elementType, func, number, object, oneOf, oneOfType, string } from "prop-types";
-import { arrayOf } from "prop-types";
 import { augmentElement, cssModule, mergeProps } from "../../shared";
 import { forwardRef } from "react";
 import { isNil } from "lodash";
@@ -34,10 +33,6 @@ const propTypes = {
      * Temporary text that occupies the select trigger when no value is selected.
      */
     placeholder: string,
-    /**
-     * Items to render.
-     */
-    items: arrayOf(object),
     /**
      * Whether or not a user input is required before form submission.
      */
@@ -124,7 +119,6 @@ export function InnerSelect(props) {
         selectedKey: selectedKeyProp,
         defaultSelectedKey,
         placeholder,
-        items,
         required,
         validationState,
         onSelectionChange,
@@ -163,7 +157,6 @@ export function InnerSelect(props) {
         defaultOpen,
         selectedKey: selectedKeyProp,
         defaultSelectedKey,
-        items,
         onSelectionChange,
         onOpenChange,
         direction,

--- a/packages/react-components/src/select/src/useSelect.js
+++ b/packages/react-components/src/select/src/useSelect.js
@@ -23,7 +23,6 @@ export function useSelect(children, {
     defaultOpen,
     selectedKey: selectedKeyProp,
     defaultSelectedKey,
-    items: itemsProp,
     onSelectionChange,
     onOpenChange,
     direction = "bottom",
@@ -116,7 +115,7 @@ export function useSelect(children, {
 
     const triggerWidth = useTriggerWidth(triggerElement, { isDisabled: !allowResponsiveMenuWidth || !isNil(menuWidth) });
 
-    const nodes = useCollection(children, { items: itemsProp });
+    const nodes = useCollection(children);
     const items = useOnlyCollectionItems(nodes);
 
     const selectedItem = useMemo(() => items.find(x => x.key === selectedKey), [items, selectedKey]);

--- a/packages/react-components/src/tabs/docs/Tabs.stories.mdx
+++ b/packages/react-components/src/tabs/docs/Tabs.stories.mdx
@@ -105,12 +105,12 @@ A tab can contains a [lozenge](?path=/docs/components-lozenge--default-story).
     </Story>
 </Preview>
 
-### Array map
+### Dynamic tabs
 
-Tabs items can be rendered with an array map.
+Tabs items can be rendered dynamically.
 
 <Preview>
-    <Story name="data tabs">
+    <Story name="dynamic tabs">
         <Tabs aria-label="Planets">
             {[
                 { id: "mars", header: "Mars", content: "Mars is the fourth planet from the Sun and the second-smallest planet." },

--- a/packages/react-components/src/tabs/tests/chromatic/Tabs.chroma.jsx
+++ b/packages/react-components/src/tabs/tests/chromatic/Tabs.chroma.jsx
@@ -303,7 +303,7 @@ stories()
             </Item>
         </Tabs>
     )
-    .add("array map", () =>
+    .add("dynamic tabs", () =>
         <Tabs aria-label="Planets">
             {["1", "2", "3"].map(x => (
                 <Item key={x}>


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing documentation
https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
-->

Issue:

## What I did

- Removed `items` prop from Autocomplete, Menu & Select since it can be done with a simple array map. Might want to add back later if you feel we need to add some kind of caching for performance.
- Renamed "Array map" docs examples to "Dynamic items"

## How to test

- Is this testable with Jest or Chromatic screenshots?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
