### PR TITLE
disabled menu item is now focusable/hoverable

### DIFF
--- a/packages/react-components/src/menu/src/Menu.css
+++ b/packages/react-components/src/menu/src/Menu.css
@@ -73,10 +73,6 @@
 .o-ui-menu-item-focus,
 .o-ui-menu-item:focus {
     outline: none;
-}
-
-.o-ui-menu-item-focus:not([aria-disabled="true"]),
-.o-ui-menu-item:focus:not([aria-disabled="true"]) {
     background-color: var(--o-ui-alias-background-4-hover);
 }
 


### PR DESCRIPTION
Issue: 

## Summary

According to WAI-ARIA a disabled menu item is focusable. This was not the case UI wise.

## What I did

Treated focus of a disabled menu item the same as a non disabled item via CSS.

## How to test

?path=/story/chromatic-menu--autofocus-first-item-when-disabled