### PR TITLE
Add end icons to tag

### DIFF
--- a/packages/react-components/src/button/docs/Button.stories.mdx
+++ b/packages/react-components/src/button/docs/Button.stories.mdx
@@ -194,8 +194,8 @@ A button content can be a single icon. An accessible name must be provided throu
 <Preview>
     <Story name="icon button">
         <Inline verticalAlign="center">
-            <IconButton shape="circular" size="sm" aria-label="Add"><AddIcon /></IconButton>
-            <IconButton shape="circular" aria-label="Add"><AddIcon /></IconButton>
+            <IconButton size="sm" aria-label="Add"><AddIcon /></IconButton>
+            <IconButton aria-label="Add"><AddIcon /></IconButton>
         </Inline>
     </Story>
 </Preview>
@@ -264,7 +264,7 @@ A toggle button content can be a single icon. An accessible name must be provide
 
 <Preview>
     <Story name="toggle icon button">
-        <ToggleIconButton variant="outline" shape="circular" aria-label="Activate">
+        <ToggleIconButton variant="outline" aria-label="Activate">
             <CheckIcon />
         </ToggleIconButton>
     </Story>

--- a/packages/react-components/src/tag/docs/Tag.stories.mdx
+++ b/packages/react-components/src/tag/docs/Tag.stories.mdx
@@ -1,5 +1,5 @@
 import { ArgsTable, Meta, Story } from "@storybook/addon-docs/blocks";
-import { CheckCircleIcon, LightbulbIcon, NotificationIcon } from "@react-components/icons";
+import { CheckCircleIcon, IconList, LightbulbIcon, NotificationIcon } from "@react-components/icons";
 import { ComponentInfo, Preview, Tagline } from "@stories/components";
 import { Counter } from "@react-components/counter";
 import { Dot } from "@react-components/dot";
@@ -44,6 +44,23 @@ A tag can contain [icons](?path=/docs/icon-gallery--page).
         <Tag>
             <CheckCircleIcon />
             <Text>Falcon 9</Text>
+        </Tag>
+    </Story>
+</Preview>
+
+### End icon
+
+*Non standard* end [icons](?path=/docs/icon-gallery--page) can be provided *only if* you have to render a [list of icons](?path=/docs/icon--default-story#icon-list).
+
+<Preview>
+    <Story name="end icon">
+        <Tag>
+            <Text>Falcon 9</Text>
+            <IconList slot="end-icon">
+                <CheckCircleIcon />
+                <LightbulbIcon />
+                <NotificationIcon />
+            </IconList>
         </Tag>
     </Story>
 </Preview>

--- a/packages/react-components/src/tag/docs/TagsPicker.sample.jsx
+++ b/packages/react-components/src/tag/docs/TagsPicker.sample.jsx
@@ -57,8 +57,8 @@ function TagsPicker() {
             <MenuTrigger closeOnSelect={false}>
                 <Button color="secondary" className="mr2">
                     <Text>{selectedKeys.length > 0 ? "Programs" : "All programs"}</Text>
-                    <DisclosureArrow slot="end-icon" />
                     {selectedKeys.length > 0 && <Counter variant="divider">{selectedKeys.length}</Counter>}
+                    <DisclosureArrow slot="end-icon" />
                 </Button>
                 <Menu
                     selectionMode="multiple"

--- a/packages/react-components/src/tag/src/Tag.css
+++ b/packages/react-components/src/tag/src/Tag.css
@@ -266,24 +266,42 @@ a.o-ui-tag-outline.o-ui-tag-disabled.o-ui-tag-hover {
     margin-right: var(--o-ui-global-scale-bravo);
 }
 
-/* CONTENT | ICON */
-.o-ui-tag:not(.o-ui-tag-fluid) .o-ui-tag-icon {
+/* CONTENT | START ICON */
+.o-ui-tag:not(.o-ui-tag-fluid) .o-ui-tag-start-icon {
     margin-right: var(--o-ui-global-scale-alpha);
 }
 
-/* CONTENT | ICON | SMALL */
-.o-ui-tag-has-icon.o-ui-tag-sm {
+/* CONTENT | START ICON | SMALL */
+.o-ui-tag-has-start-icon.o-ui-tag-sm {
     padding-left: calc(var(--o-ui-padding-sm) / 1.5);
 }
 
-/* CONTENT | ICON | MEDIUM */
-.o-ui-tag-has-icon.o-ui-tag-md {
+/* CONTENT | START ICON | MEDIUM */
+.o-ui-tag-has-start-icon.o-ui-tag-md {
     padding-left: calc(var(--o-ui-padding-md) / 1.5);
+}
+
+/* CONTENT | END ICON */
+.o-ui-tag:not(.o-ui-tag-fluid) .o-ui-tag-end-icon {
+    margin-left: var(--o-ui-global-scale-alpha);
+}
+
+/* CONTENT | END ICON | SMALL */
+.o-ui-tag-has-end-icon.o-ui-tag-sm {
+    padding-right: calc(var(--o-ui-padding-sm) / 1.5);
+}
+
+/* CONTENT | END ICON | MEDIUM */
+.o-ui-tag-has-end-icon.o-ui-tag-md {
+    padding-right: calc(var(--o-ui-padding-md) / 1.5);
 }
 
 /* CONTENT | TEXT */
 .o-ui-tag-text {
     flex-grow: 1;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 /* CONTENT | REMOVE BUTTON */

--- a/packages/react-components/src/tag/src/Tag.tsx
+++ b/packages/react-components/src/tag/src/Tag.tsx
@@ -61,13 +61,13 @@ export function InnerTag({
 }: InnerTagProps) {
     const ref = useMergedRefs(forwardedRef);
 
-    const { icon, dot, text, counter } = useSlots(children, useMemo(() => ({
+    const { icon, dot, text, "end-icon": endIcon, counter } = useSlots(children, useMemo(() => ({
         _: {
             defaultWrapper: Text
         },
         icon: {
             size: embeddedIconSize(size),
-            className: "o-ui-tag-icon"
+            className: "o-ui-tag-start-icon"
         },
         dot: {
             disabled,
@@ -77,6 +77,10 @@ export function InnerTag({
             color: "inherit",
             size,
             className: "o-ui-tag-text"
+        },
+        "end-icon": {
+            size: embeddedIconSize(size),
+            className: "o-ui-tag-end-icon"
         },
         counter: {
             color: "inherit",
@@ -102,7 +106,8 @@ export function InnerTag({
                     className: cssModule(
                         "o-ui-tag",
                         variant,
-                        icon && "has-icon",
+                        icon && "has-start-icon",
+                        endIcon && "has-end-icon",
                         removeMarkup && "has-remove-button",
                         fluid && "fluid",
                         active && "active",
@@ -119,6 +124,7 @@ export function InnerTag({
             {icon}
             {dot}
             {text}
+            {endIcon}
             {counter}
             {removeMarkup}
         </Box>

--- a/packages/react-components/src/tag/tests/chromatic/createTagTestSuite.jsx
+++ b/packages/react-components/src/tag/tests/chromatic/createTagTestSuite.jsx
@@ -17,12 +17,8 @@ export function createTagTestSuite(element, stories) {
                     <Tag size="sm" element={element}>Falcon 9</Tag>
                     <Tag element={element}>Falcon 9</Tag>
                 </Inline>
-                <Inline>
-                    <Tag fluid element={element}>Falcon 9</Tag>
-                </Inline>
-                <Inline className="w-10">
-                    <Tag fluid element={element}>Falcon 9</Tag>
-                </Inline>
+                <Tag fluid element={element}>Falcon 9</Tag>
+                <Tag fluid element={element}>Falcon 9</Tag>
             </Stack>
         )
         .add("icon", () =>
@@ -51,18 +47,58 @@ export function createTagTestSuite(element, stories) {
                         <Text>Falcon 9</Text>
                     </Tag>
                 </Inline>
-                <Inline>
+                <Tag fluid element={element}>
+                    <CheckCircleIcon />
+                    <Text>Falcon 9</Text>
+                </Tag>
+                <div className="w-10">
                     <Tag fluid element={element}>
                         <CheckCircleIcon />
                         <Text>Falcon 9</Text>
                     </Tag>
-                </Inline>
-                <Inline className="w-10">
-                    <Tag fluid element={element}>
-                        <CheckCircleIcon />
+                </div>
+                <Inline verticalAlign="end">
+                    <Tag size="sm" element={element}>
                         <Text>Falcon 9</Text>
+                        <IconList slot="end-icon">
+                            <CheckCircleIcon /><CheckCircleIcon /><CheckCircleIcon />
+                        </IconList>
+                    </Tag>
+                    <Tag element={element}>
+                        <Text>Falcon 9</Text>
+                        <IconList slot="end-icon">
+                            <CheckCircleIcon /><CheckCircleIcon /><CheckCircleIcon />
+                        </IconList>
                     </Tag>
                 </Inline>
+                <Tag fluid element={element}>
+                    <Text>Falcon 9</Text>
+                    <IconList slot="end-icon">
+                        <CheckCircleIcon /><CheckCircleIcon /><CheckCircleIcon />
+                    </IconList>
+                </Tag>
+                <div className="w-10">
+                    <Tag fluid element={element}>
+                        <Text>Falcon 9</Text>
+                        <IconList slot="end-icon">
+                            <CheckCircleIcon /><CheckCircleIcon /><CheckCircleIcon />
+                        </IconList>
+                    </Tag>
+                </div>
+                <Tag element={element}>
+                    <CheckCircleIcon />
+                    <Text>Falcon 9</Text>
+                    <IconList slot="end-icon">
+                        <CheckCircleIcon /><CheckCircleIcon /><CheckCircleIcon />
+                    </IconList>
+                </Tag>
+                <Tag fluid element={element}>
+                    <CheckCircleIcon />
+                    <Text>Falcon 9</Text>
+                    <IconList slot="end-icon">
+                        <CheckCircleIcon /><CheckCircleIcon /><CheckCircleIcon />
+                    </IconList>
+                </Tag>
             </Stack>
         )
         .add("dot", () =>
@@ -77,18 +113,14 @@ export function createTagTestSuite(element, stories) {
                         <Text>Falcon 9</Text>
                     </Tag>
                 </Inline>
-                <Inline>
-                    <Tag fluid element={element}>
-                        <Dot />
-                        <Text>Falcon 9</Text>
-                    </Tag>
-                </Inline>
-                <Inline className="w-10">
-                    <Tag fluid element={element}>
-                        <Dot />
-                        <Text>Falcon 9</Text>
-                    </Tag>
-                </Inline>
+                <Tag fluid element={element}>
+                    <Dot />
+                    <Text>Falcon 9</Text>
+                </Tag>
+                <Tag fluid element={element}>
+                    <Dot />
+                    <Text>Falcon 9</Text>
+                </Tag>
             </Stack>
         )
         .add("counter", () =>
@@ -103,18 +135,16 @@ export function createTagTestSuite(element, stories) {
                         <Counter variant="divider">60</Counter>
                     </Tag>
                 </Inline>
-                <Inline>
-                    <Tag fluid element={element}>
-                        <Text>Falcon 9</Text>
-                        <Counter>60</Counter>
-                    </Tag>
-                </Inline>
-                <Inline className="w-10">
+                <Tag fluid element={element}>
+                    <Text>Falcon 9</Text>
+                    <Counter>60</Counter>
+                </Tag>
+                <div className="w-10">
                     <Tag fluid element={element}>
                         <Text>Falcon 9</Text>
                         <Counter variant="divider">60</Counter>
                     </Tag>
-                </Inline>
+                </div>
             </Stack>
         )
         .add("remove button", () =>
@@ -127,16 +157,14 @@ export function createTagTestSuite(element, stories) {
                         Falcon 9
                     </Tag>
                 </Inline>
-                <Inline>
+                <Tag fluid onRemove={() => {}} element={element}>
+                        Falcon 9
+                </Tag>
+                <div className="w-10">
                     <Tag fluid onRemove={() => {}} element={element}>
                         Falcon 9
                     </Tag>
-                </Inline>
-                <Inline className="w-10">
-                    <Tag fluid onRemove={() => {}} element={element}>
-                        Falcon 9
-                    </Tag>
-                </Inline>
+                </div>
             </Stack>
         )
         .add("as link", () =>

--- a/packages/react-components/src/tag/tests/chromatic/createTagTestSuite.jsx
+++ b/packages/react-components/src/tag/tests/chromatic/createTagTestSuite.jsx
@@ -18,7 +18,9 @@ export function createTagTestSuite(element, stories) {
                     <Tag element={element}>Falcon 9</Tag>
                 </Inline>
                 <Tag fluid element={element}>Falcon 9</Tag>
-                <Tag fluid element={element}>Falcon 9</Tag>
+                <div className="w-10">
+                    <Tag fluid element={element}>Falcon 9</Tag>
+                </div>
             </Stack>
         )
         .add("icon", () =>
@@ -117,10 +119,12 @@ export function createTagTestSuite(element, stories) {
                     <Dot />
                     <Text>Falcon 9</Text>
                 </Tag>
-                <Tag fluid element={element}>
-                    <Dot />
-                    <Text>Falcon 9</Text>
-                </Tag>
+                <div className="w-10">
+                    <Tag fluid element={element}>
+                        <Dot />
+                        <Text>Falcon 9</Text>
+                    </Tag>
+                </div>
             </Stack>
         )
         .add("counter", () =>


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Issue: https://github.com/gsoft-inc/sg-orbit/issues/589 https://github.com/gsoft-inc/sg-orbit/issues/587

## What I did

- Added an end icon to the `<Tag>` component

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes

- Does this need an update to the documentation? Yes

If your answer is yes to any of these, please make sure to include it in your PR.
