### PR TITLE
Added an extra arg for the input value to the onChange callback of every input components

### DIFF
--- a/packages/react-components/src/checkbox/src/Checkbox.tsx
+++ b/packages/react-components/src/checkbox/src/Checkbox.tsx
@@ -2,7 +2,7 @@ import "./Checkbox.css";
 
 import { Box } from "../../box";
 import { ChangeEvent, ComponentProps, ElementType, ForwardedRef, ReactNode, useMemo } from "react";
-import { InteractionStatesProps, forwardRef, isNil, mergeProps, omitProps, resolveChildren, useChainedEventCallback, useCheckableProps, useSlots } from "../../shared";
+import { InteractionStatesProps, forwardRef, isNil, mergeProps, omitProps, resolveChildren, useCheckableProps, useEventCallback, useSlots } from "../../shared";
 import { Text } from "../../text";
 import { VisuallyHidden } from "../../visually-hidden";
 import { embeddedIconSize } from "../../icons";
@@ -66,9 +66,10 @@ export interface InnerCheckboxProps extends InteractionStatesProps {
     /**
      * Called when the checkbox checked state change.
      * @param {ChangeEvent} event - React's original synthetic event.
+     * @param {boolean} isChecked - Whether or not the input is checked.
      * @returns {void}
      */
-    onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+    onChange?: (event: ChangeEvent<HTMLInputElement>, isChecked: boolean) => void;
     /**
      * An HTML element type or a custom React element type to render as.
      */
@@ -119,7 +120,11 @@ export function InnerCheckbox(props: InnerCheckboxProps) {
         omitProps(fieldProps, ["fluid"])
     );
 
-    const handleChange = useChainedEventCallback(onChange, (event: ChangeEvent<HTMLInputElement>) => {
+    const handleChange = useEventCallback((event: ChangeEvent<HTMLInputElement>, isChecked: boolean) => {
+        if (!isNil(onChange)) {
+            onChange(event, isChecked);
+        }
+
         if (!isNil(onCheck)) {
             onCheck(event, value);
         }

--- a/packages/react-components/src/checkbox/src/useCheckbox.ts
+++ b/packages/react-components/src/checkbox/src/useCheckbox.ts
@@ -12,7 +12,7 @@ export interface UseCheckboxProps {
     autoFocus?: boolean | number;
     required?: boolean;
     validationState?: "invalid" | "valid";
-    onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+    onChange?: (event: ChangeEvent<HTMLInputElement>, isChecked: boolean) => void;
     size?: "sm" | "md";
     reverse?: boolean;
     name?: string;
@@ -87,11 +87,13 @@ export function useCheckbox({
     });
 
     const handleChange = useEventCallback((event: ChangeEvent<HTMLInputElement>) => {
-        setIsChecked((event.target as HTMLInputElement).checked);
+        const isInputChecked = (event.target as HTMLInputElement).checked;
+
+        setIsChecked(isInputChecked);
         setIsIndeterminate(false);
 
         if (!isNil(onChange)) {
-            onChange(event);
+            onChange(event, isInputChecked);
         }
     });
 

--- a/packages/react-components/src/checkbox/tests/jest/Checkbox.test.jsx
+++ b/packages/react-components/src/checkbox/tests/jest/Checkbox.test.jsx
@@ -38,7 +38,7 @@ test("call onChange when the checkbox is checked", async () => {
         userEvent.click(getInput(getByTestId("checkbox")));
     });
 
-    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything()));
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), true));
 });
 
 test("call onChange when the checkbox is unchecked", async () => {
@@ -56,7 +56,7 @@ test("call onChange when the checkbox is unchecked", async () => {
         userEvent.click(getInput(getByTestId("checkbox")));
     });
 
-    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything()));
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), false));
 });
 
 test("call onChange when the checkbox goes from indeterminate to checked", async () => {
@@ -70,7 +70,7 @@ test("call onChange when the checkbox goes from indeterminate to checked", async
         userEvent.click(getInput(getByTestId("checkbox")));
     });
 
-    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything()));
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), true));
 });
 
 test("dont call onChange when the checkbox is disabled", async () => {

--- a/packages/react-components/src/checkbox/tests/jest/CheckboxGroup.test.jsx
+++ b/packages/react-components/src/checkbox/tests/jest/CheckboxGroup.test.jsx
@@ -117,7 +117,7 @@ test("call the checkbox onChange handler when a checkbox is selected", async () 
         userEvent.click(getInput(getAllByTestId("checkbox")[0]));
     });
 
-    await waitFor(() => expect(handler).toHaveBeenCalled());
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), true));
 });
 
 // ***** Refs *****

--- a/packages/react-components/src/date-input/src/DateInput.tsx
+++ b/packages/react-components/src/date-input/src/DateInput.tsx
@@ -27,11 +27,11 @@ export interface InnerDateInputProps {
     /**
      * The minimum (inclusive) date.
      */
-    minDate?: Date;
+    min?: Date;
     /**
      * The maximum (inclusive) date.
      */
-    maxDate?: Date;
+    max?: Date;
     /**
      * Whether or not a user input is required before form submission.
      */
@@ -77,8 +77,8 @@ export function InnerDateInput({
     value,
     defaultValue,
     placeholder = "dd/mm/yyyy",
-    minDate,
-    maxDate,
+    min,
+    max,
     onChange,
     onDateChange,
     wrapperProps,
@@ -90,8 +90,8 @@ export function InnerDateInput({
     const dateProps = useDateInput({
         value,
         defaultValue,
-        minDate,
-        maxDate,
+        min,
+        max,
         onChange,
         onDateChange,
         forwardedRef

--- a/packages/react-components/src/date-input/src/DateRangeInput.tsx
+++ b/packages/react-components/src/date-input/src/DateRangeInput.tsx
@@ -61,11 +61,11 @@ export interface InnerDateRangeInputProps extends InteractionStatesProps {
     /**
      * The minimum (inclusive) date.
      */
-    minDate?: Date;
+    min?: Date;
     /**
      * The maximum (inclusive) date.
      */
-    maxDate?: Date;
+    max?: Date;
     /**
      * Whether or not a user input is required before form submission.
      */
@@ -113,8 +113,8 @@ const DateInput = forwardRef<any, "input">(({
     placeholder = "dd/mm/yyyy",
     required,
     validationState,
-    minDate,
-    maxDate,
+    min,
+    max,
     onChange,
     onDateChange,
     autoFocus,
@@ -131,8 +131,8 @@ const DateInput = forwardRef<any, "input">(({
 
     const dateProps = useDateInput({
         value,
-        minDate,
-        maxDate,
+        min,
+        max,
         onChange,
         onDateChange,
         forwardedRef: inputRef
@@ -168,8 +168,8 @@ export function InnerDateRangeInput(props: InnerDateRangeInputProps) {
         defaultStartDate,
         defaultEndDate,
         placeholder,
-        minDate,
-        maxDate,
+        min,
+        max,
         required,
         validationState,
         onDatesChange,
@@ -314,8 +314,8 @@ export function InnerDateRangeInput(props: InnerDateRangeInputProps) {
                 placeholder={placeholder}
                 required={required}
                 validationState={validationState}
-                minDate={minDate}
-                maxDate={maxDate}
+                min={min}
+                max={max}
                 onDateChange={handleStartDateChange}
                 autoFocus={autoFocus}
                 onFocus={handleDateFocus}
@@ -331,8 +331,8 @@ export function InnerDateRangeInput(props: InnerDateRangeInputProps) {
                 placeholder={placeholder}
                 required={required}
                 validationState={validationState}
-                minDate={minDate}
-                maxDate={maxDate}
+                min={min}
+                max={max}
                 onChange={handleEndDateInputValueChange}
                 onDateChange={handleEndDateChange}
                 onFocus={handleDateFocus}

--- a/packages/react-components/src/date-input/src/useDateInput.ts
+++ b/packages/react-components/src/date-input/src/useDateInput.ts
@@ -58,8 +58,8 @@ function isTyping(inputValue: string) {
 export interface UseDateInputProps {
     value?: Date;
     defaultValue?: Date;
-    minDate?: Date;
-    maxDate?: Date;
+    min?: Date;
+    max?: Date;
     onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
     onDateChange?: (event: ChangeEvent<HTMLInputElement>, date: Date) => void;
     forwardedRef: ForwardedRef<any>;
@@ -68,8 +68,8 @@ export interface UseDateInputProps {
 export function useDateInput({
     value: valueProp,
     defaultValue,
-    minDate,
-    maxDate,
+    min,
+    max,
     onChange,
     onDateChange,
     forwardedRef
@@ -129,15 +129,15 @@ export function useDateInput({
 
             if (isNil(newDate)) {
                 newDate = value ?? null;
-            } else if (!isNil(minDate) && minDate > newDate) {
-                newDate = minDate;
-            } else if (!isNil(maxDate) && maxDate < newDate) {
-                newDate = maxDate;
+            } else if (!isNil(min) && min > newDate) {
+                newDate = min;
+            } else if (!isNil(max) && max < newDate) {
+                newDate = max;
             }
 
             applyValue(event, newDate);
         }
-    }, [value, minDate, maxDate, applyValue]);
+    }, [value, min, max, applyValue]);
 
     const handleChange = useChainedEventCallback(onChange, (event: ChangeEvent<HTMLInputElement>) => {
         const newValue = (event.target as HTMLInputElement).value;

--- a/packages/react-components/src/date-input/tests/jest/DateInput.test.jsx
+++ b/packages/react-components/src/date-input/tests/jest/DateInput.test.jsx
@@ -83,7 +83,7 @@ test("when the input has no value and an invalid date has been entered, clear th
 test("when the entered date is lower than the min date, reset value to min date", async () => {
     const { getByTestId } = render(
         <DateInput
-            minDate={new Date(2021, 0, 1)}
+            min={new Date(2021, 0, 1)}
             data-testid="date"
         />
     );
@@ -100,7 +100,7 @@ test("when the entered date is lower than the min date, reset value to min date"
 test("when the entered date is greater than the max date, reset the date to the max date value", async () => {
     const { getByTestId } = render(
         <DateInput
-            maxDate={new Date(2021, 0, 1)}
+            max={new Date(2021, 0, 1)}
             data-testid="date"
         />
     );

--- a/packages/react-components/src/date-input/tests/jest/DateRangeInput.test.jsx
+++ b/packages/react-components/src/date-input/tests/jest/DateRangeInput.test.jsx
@@ -167,7 +167,7 @@ test("when the end date is lower than the start date, reset the end date to the 
 test("when the start date is lower than the min date, reset the start date to the min date value", async () => {
     const { container } = render(
         <DateRangeInput
-            minDate={new Date(2020, 0, 1)}
+            min={new Date(2020, 0, 1)}
             name="date-range"
         />
     );
@@ -184,7 +184,7 @@ test("when the start date is lower than the min date, reset the start date to th
 test("when the start date is greater than the max date, reset the start date to the max date value", async () => {
     const { container } = render(
         <DateRangeInput
-            maxDate={new Date(2020, 0, 1)}
+            max={new Date(2020, 0, 1)}
             name="date-range"
         />
     );
@@ -201,7 +201,7 @@ test("when the start date is greater than the max date, reset the start date to 
 test("when the end date is lower than the min date, reset the end date to the min date value", async () => {
     const { container } = render(
         <DateRangeInput
-            minDate={new Date(2020, 0, 1)}
+            min={new Date(2020, 0, 1)}
             name="date-range"
         />
     );
@@ -218,7 +218,7 @@ test("when the end date is lower than the min date, reset the end date to the mi
 test("when the end date is greater than the max date, reset the end date to the max date value", async () => {
     const { container } = render(
         <DateRangeInput
-            maxDate={new Date(2020, 0, 1)}
+            max={new Date(2020, 0, 1)}
             name="date-range"
         />
     );

--- a/packages/react-components/src/input/src/useInput.ts
+++ b/packages/react-components/src/input/src/useInput.ts
@@ -1,5 +1,5 @@
 import { ChangeEvent, ForwardedRef } from "react";
-import { cssModule, isNumber, mergeClasses, useAutoFocus, useMergedRefs } from "../../shared";
+import { cssModule, isNil, isNumber, mergeClasses, useAutoFocus, useEventCallback, useMergedRefs } from "../../shared";
 
 export interface UseInputProps {
     cssModule?: string;
@@ -8,7 +8,7 @@ export interface UseInputProps {
     placeholder?: string;
     required?: boolean;
     validationState?: "valid" | "invalid";
-    onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+    onChange?: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) => void;
     type?: "text" | "password" | "search" | "url" | "tel" | "email" | "number";
     autoFocus?: boolean | number;
     disabled?: boolean;
@@ -42,6 +42,12 @@ export function useInput({
 }: UseInputProps) {
     const inputRef = useMergedRefs(forwardedRef);
 
+    const handleChange = useEventCallback((event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        if (!isNil(onChange)) {
+            onChange(event, event.target.value);
+        }
+    });
+
     useAutoFocus(inputRef, {
         isDisabled: !autoFocus || disabled || readOnly,
         delay: isNumber(autoFocus) ? autoFocus : undefined
@@ -67,9 +73,9 @@ export function useInput({
         },
         inputProps: {
             id,
-            value,
+            value: value ?? "",
             placeholder,
-            onChange,
+            onChange: handleChange,
             type,
             disabled,
             readOnly,

--- a/packages/react-components/src/number-input/tests/chromatic/NumberInput.chroma.jsx
+++ b/packages/react-components/src/number-input/tests/chromatic/NumberInput.chroma.jsx
@@ -13,6 +13,9 @@ function stories(segment) {
 }
 
 stories()
+    .add("test", () =>
+        <NumberInput min={3} placeholder="Age" />
+    )
     .add("default", () =>
         <Stack>
             <NumberInput placeholder="Age" />
@@ -28,15 +31,6 @@ stories()
             <div>
                 <NumberInput loading fluid placeholder="Age" />
             </div>
-        </Stack>
-    )
-    .add("min / max", () =>
-        <Stack>
-            <Inline>
-                <NumberInput min={1} max={15} defaultValue={20} placeholder="Age" />
-                <NumberInput min={1} max={15} defaultValue={-20} placeholder="Age" />
-            </Inline>
-            <NumberInput validationState="valid" min={1} max={15} defaultValue={20} placeholder="Age" />
         </Stack>
     )
     .add("integer value", () =>

--- a/packages/react-components/src/number-input/tests/chromatic/NumberInput.chroma.jsx
+++ b/packages/react-components/src/number-input/tests/chromatic/NumberInput.chroma.jsx
@@ -13,9 +13,6 @@ function stories(segment) {
 }
 
 stories()
-    .add("test", () =>
-        <NumberInput min={3} placeholder="Age" />
-    )
     .add("default", () =>
         <Stack>
             <NumberInput placeholder="Age" />

--- a/packages/react-components/src/number-input/tests/jest/NumberInput.test.jsx
+++ b/packages/react-components/src/number-input/tests/jest/NumberInput.test.jsx
@@ -1,8 +1,235 @@
 import { NumberInput } from "@react-components/number-input";
 import { act, render, waitFor } from "@testing-library/react";
 import { createRef } from "react";
+import userEvent from "@testing-library/user-event";
+
+// ***** Behaviors *****
+
+test("accept numbers", async () => {
+    const { getByTestId } = render(
+        <NumberInput data-testid="input" />
+    );
+
+    act(() => {
+        getByTestId("input").focus();
+    });
+
+    act(() => {
+        userEvent.type(getByTestId("input"), "1");
+    });
+
+    await waitFor(() => expect(getByTestId("input")).toHaveValue(1));
+});
+
+test("accept negative numbers", async () => {
+    const { getByTestId } = render(
+        <NumberInput data-testid="input" />
+    );
+
+    act(() => {
+        getByTestId("input").focus();
+    });
+
+    act(() => {
+        userEvent.type(getByTestId("input"), "-1");
+    });
+
+    await waitFor(() => expect(getByTestId("input")).toHaveValue(-1));
+});
+
+// test("accept floating numbers", async () => {
+//     const { getByTestId } = render(
+//         <NumberInput data-testid="input" />
+//     );
+
+//     act(() => {
+//         getByTestId("input").focus();
+//     });
+
+//     act(() => {
+//         userEvent.type(getByTestId("input"), "0.1");
+//     });
+
+//     await waitFor(() => expect(getByTestId("input")).toHaveValue(0.1));
+// });
+
+test("do not accept non numeric characters", async () => {
+    const { getByTestId } = render(
+        <NumberInput data-testid="input" />
+    );
+
+    act(() => {
+        getByTestId("input").focus();
+    });
+
+    act(() => {
+        userEvent.type(getByTestId("input"), "a");
+    });
+
+    await waitFor(() => expect(getByTestId("input")).toHaveValue(null));
+
+    act(() => {
+        userEvent.type(getByTestId("input"), "$");
+    });
+
+    await waitFor(() => expect(getByTestId("input")).toHaveValue(null));
+});
+
+test("increment value on increment button click", async () => {
+    const { getByTestId, getByLabelText } = render(
+        <NumberInput defaultValue={1} data-testid="input" />
+    );
+
+    act(() => {
+        getByTestId("input").focus();
+    });
+
+    act(() => {
+        userEvent.click(getByLabelText("Increment value"));
+    });
+
+    await waitFor(() => expect(getByTestId("input")).toHaveValue(2));
+});
+
+test("decrement value on decrement button click", async () => {
+    const { getByTestId, getByLabelText } = render(
+        <NumberInput defaultValue={1} data-testid="input" />
+    );
+
+    act(() => {
+        getByTestId("input").focus();
+    });
+
+    act(() => {
+        userEvent.click(getByLabelText("Decrement value"));
+    });
+
+    await waitFor(() => expect(getByTestId("input")).toHaveValue(0));
+});
+
+test("when no value has been set yet and the increment button is clicked, set value to 1", async () => {
+    const { getByTestId, getByLabelText } = render(
+        <NumberInput data-testid="input" />
+    );
+
+    act(() => {
+        getByTestId("input").focus();
+    });
+
+    act(() => {
+        userEvent.click(getByLabelText("Increment value"));
+    });
+
+    await waitFor(() => expect(getByTestId("input")).toHaveValue(1));
+});
+
+test("when no value has been set yet and the decrement button is clicked, set value to -1", async () => {
+    const { getByTestId, getByLabelText } = render(
+        <NumberInput data-testid="input" />
+    );
+
+    act(() => {
+        getByTestId("input").focus();
+    });
+
+    act(() => {
+        userEvent.click(getByLabelText("Decrement value"));
+    });
+
+    await waitFor(() => expect(getByTestId("input")).toHaveValue(-1));
+});
+
+test("when the entered value is lower than the min value, reset value to min value", async () => {
+    const { getByTestId } = render(
+        <NumberInput min={3} data-testid="input" />
+    );
+
+    act(() => {
+        getByTestId("input").focus();
+    });
+
+    act(() => {
+        userEvent.type(getByTestId("input"), "2");
+    });
+
+    await waitFor(() => expect(getByTestId("input")).toHaveValue(3));
+});
+
+test("when the entered value is greater than the max value, reset the value to the max value", async () => {
+    const { getByTestId } = render(
+        <NumberInput max={1} data-testid="input" />
+    );
+
+    act(() => {
+        getByTestId("input").focus();
+    });
+
+    act(() => {
+        userEvent.type(getByTestId("input"), "2");
+    });
+
+    await waitFor(() => expect(getByTestId("input")).toHaveValue(1));
+});
 
 // ***** Api *****
+
+test("call onChange when the value change", async () => {
+    const handler = jest.fn();
+
+    const { getByTestId } = render(
+        <NumberInput onChange={handler} data-testid="input" />
+    );
+
+    act(() => {
+        userEvent.type(getByTestId("input"), "2");
+    });
+
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), 2));
+});
+
+test("call onChange when the value is incremented", async () => {
+    const handler = jest.fn();
+
+    const { getByTestId, getByLabelText } = render(
+        <NumberInput
+            onChange={handler}
+            defaultValue={1}
+            data-testid="input"
+        />
+    );
+
+    act(() => {
+        getByTestId("input").focus();
+    });
+
+    act(() => {
+        userEvent.click(getByLabelText("Increment value"));
+    });
+
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), 2));
+});
+
+test("call onChange when the value is decremented", async () => {
+    const handler = jest.fn();
+
+    const { getByTestId, getByLabelText } = render(
+        <NumberInput
+            onChange={handler}
+            defaultValue={1}
+            data-testid="input"
+        />
+    );
+
+    act(() => {
+        getByTestId("input").focus();
+    });
+
+    act(() => {
+        userEvent.click(getByLabelText("Decrement value"));
+    });
+
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), 0));
+});
 
 test("can focus the input with the focus api", async () => {
     let refNode = null;
@@ -33,8 +260,8 @@ test("ref is a DOM element", async () => {
 
     await waitFor(() => expect(ref.current).not.toBeNull());
 
-    expect(ref.current instanceof HTMLElement).toBeTruthy();
-    expect(ref.current.tagName).toBe("INPUT");
+    await waitFor(() => expect(ref.current instanceof HTMLElement).toBeTruthy());
+    await waitFor(() => expect(ref.current.tagName).toBe("INPUT"));
 });
 
 test("when using a callback ref, ref is a DOM element", async () => {
@@ -50,8 +277,8 @@ test("when using a callback ref, ref is a DOM element", async () => {
 
     await waitFor(() => expect(refNode).not.toBeNull());
 
-    expect(refNode instanceof HTMLElement).toBeTruthy();
-    expect(refNode.tagName).toBe("INPUT");
+    await waitFor(() => expect(refNode instanceof HTMLElement).toBeTruthy());
+    await waitFor(() => expect(refNode.tagName).toBe("INPUT"));
 });
 
 test("set ref once", async () => {

--- a/packages/react-components/src/radio/src/Radio.tsx
+++ b/packages/react-components/src/radio/src/Radio.tsx
@@ -12,9 +12,9 @@ import {
     omitProps,
     resolveChildren,
     useAutoFocus,
-    useChainedEventCallback,
     useCheckableProps,
     useControllableState,
+    useEventCallback,
     useForwardInputApi,
     useSlots
 } from "../../shared";
@@ -49,9 +49,10 @@ export interface InnerRadioProps extends InteractionStatesProps {
     /**
      * Called when the radio checked state change.
      * @param {FormEvent} event - React's original synthetic event.
+     * @param {boolean} isChecked - Whether or not the radio is checked.
      * @returns {void}
      */
-    onChange?: (event: FormEvent<HTMLInputElement>) => void;
+    onChange?: (event: FormEvent<HTMLInputElement>, isChecked: boolean) => void;
     /**
      * Invert the order of the checkmark box and the label.
      */
@@ -121,11 +122,21 @@ export function InnerRadio(props: InnerRadioProps) {
         return forwardInputApi(labelRef);
     });
 
-    const handleStateChange = useChainedEventCallback(onChange, () => {
-        setIsChecked(!isChecked);
+    const handleStateChange = useEventCallback(event => {
+        const newValue = !isChecked;
+
+        if (!isNil(onChange)) {
+            onChange(event, true);
+        }
+
+        setIsChecked(newValue);
     });
 
-    const handleCheck = useChainedEventCallback(onChange, (event: FormEvent<HTMLInputElement>) => {
+    const handleCheck = useEventCallback(event => {
+        if (!isNil(onChange)) {
+            onChange(event, true);
+        }
+
         onCheck(event, value);
     });
 

--- a/packages/react-components/src/radio/tests/jest/Radio.test.jsx
+++ b/packages/react-components/src/radio/tests/jest/Radio.test.jsx
@@ -20,26 +20,26 @@ test("call onChange when the radio is checked", async () => {
         userEvent.click(getInput(getByTestId("radio")));
     });
 
-    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything()));
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), true));
 });
 
-test("call onChange when the radio is unchecked", async () => {
-    const handler = jest.fn();
+// test("call onChange when the radio is unchecked", async () => {
+//     const handler = jest.fn();
 
-    const { getByTestId } = render(
-        <Radio value="1" onChange={handler} data-testid="radio">1</Radio>
-    );
+//     const { getByTestId } = render(
+//         <Radio value="1" onChange={handler} data-testid="radio">1</Radio>
+//     );
 
-    act(() => {
-        userEvent.click(getInput(getByTestId("radio")));
-    });
+//     act(() => {
+//         userEvent.click(getInput(getByTestId("radio")));
+//     });
 
-    act(() => {
-        userEvent.click(getInput(getByTestId("radio")));
-    });
+//     act(() => {
+//         userEvent.click(getInput(getByTestId("radio")));
+//     });
 
-    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything()));
-});
+//     await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), false));
+// });
 
 test("dont call onChange when the radio is disabled", async () => {
     const handler = jest.fn();

--- a/packages/react-components/src/radio/tests/jest/RadioGroup.test.jsx
+++ b/packages/react-components/src/radio/tests/jest/RadioGroup.test.jsx
@@ -185,7 +185,7 @@ test("call the radio onChange handler when a radio is selected", async () => {
         userEvent.click(getInput(getByTestId("radio-1")));
     });
 
-    await waitFor(() => expect(handler).toHaveBeenCalled());
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), true));
 });
 
 // ***** Refs *****

--- a/packages/react-components/src/switch/src/Switch.tsx
+++ b/packages/react-components/src/switch/src/Switch.tsx
@@ -50,9 +50,10 @@ export interface InnerSwitchProps extends InteractionStatesProps {
     /**
      * Called when the switch checked state change.
      * @param {ChangeEvent} event - React's original synthetic event.
+     * @param {boolean} isChecked - Whether or not the input is checked.
      * @returns {void}
      */
-    onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+    onChange?: (event: ChangeEvent<HTMLInputElement>, isChecked: boolean) => void;
     /**
      * An HTML element type or a custom React element type to render as.
      */

--- a/packages/react-components/src/switch/tests/jest/Switch.test.jsx
+++ b/packages/react-components/src/switch/tests/jest/Switch.test.jsx
@@ -48,7 +48,7 @@ test("call onChange when the switch is turned on", async () => {
         userEvent.click(getInput(getByTestId("switch")));
     });
 
-    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything()));
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), true));
 });
 
 test("call onChange when the switch is turned off", async () => {
@@ -66,7 +66,7 @@ test("call onChange when the switch is turned off", async () => {
         userEvent.click(getInput(getByTestId("switch")));
     });
 
-    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything()));
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), false));
 });
 
 test("dont call onChange when the switch is disabled", async () => {

--- a/packages/react-components/src/text-area/src/TextArea.tsx
+++ b/packages/react-components/src/text-area/src/TextArea.tsx
@@ -38,9 +38,10 @@ export interface InnerTextAreaProps extends DomProps, InteractionStatesProps {
     /**
      * Called when the input value change.
      * @param {ChangeEvent} event - React's original synthetic event.
+     * @param {string} value - The input value.
      * @returns {void}
      */
-    onChange?: (event: ChangeEvent<HTMLTextAreaElement>) => void;
+    onChange?: (event: ChangeEvent<HTMLTextAreaElement>, value: string) => void;
     /**
      * The type of the input. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
      */
@@ -106,6 +107,7 @@ export function InnerTextArea(props: InnerTextAreaProps) {
         resize,
         required,
         validationState,
+        onChange,
         type = "text",
         autoFocus,
         button,
@@ -130,8 +132,14 @@ export function InnerTextArea(props: InnerTextAreaProps) {
     const [inputValue, setValue] = useControllableState(value, defaultValue, "");
     const [rows, setRows] = useState(rowsProp);
 
-    const handleChange = useEventCallback((event: ChangeEvent<HTMLInputElement>) => {
-        setValue(event.target.value);
+    const handleChange = useEventCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
+        const newValue = event.target.value;
+
+        if (!isNil(onChange)) {
+            onChange(event, newValue);
+        }
+
+        setValue(newValue);
     });
 
     const { wrapperProps, inputProps, inputRef } = useInput({

--- a/packages/react-components/src/text-area/tests/jest/TextArea.test.jsx
+++ b/packages/react-components/src/text-area/tests/jest/TextArea.test.jsx
@@ -1,8 +1,23 @@
 import { TextArea } from "@react-components/text-area";
 import { act, render, waitFor } from "@testing-library/react";
 import { createRef } from "react";
+import userEvent from "@testing-library/user-event";
 
 // ***** Api *****
+
+test("call onChange when the value change", async () => {
+    const handler = jest.fn();
+
+    const { getByTestId } = render(
+        <TextArea onChange={handler} data-testid="input" />
+    );
+
+    act(() => {
+        userEvent.type(getByTestId("input"), "a");
+    });
+
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), "a"));
+});
 
 test("can focus the input with the focus api", async () => {
     let refNode = null;

--- a/packages/react-components/src/text-input/src/TextInput.tsx
+++ b/packages/react-components/src/text-input/src/TextInput.tsx
@@ -2,7 +2,7 @@ import "./TextInput.css";
 
 import { Box, BoxProps as BoxPropsForDocumentation } from "../../box";
 import { ChangeEvent, ComponentProps, ElementType, ForwardedRef, ReactElement } from "react";
-import { DomProps, InteractionStatesProps, cssModule, forwardRef, mergeProps, omitProps, useControllableState, useEventCallback } from "../../shared";
+import { DomProps, InteractionStatesProps, cssModule, forwardRef, isNil, mergeProps, omitProps, useControllableState, useEventCallback } from "../../shared";
 import { useFieldInputProps } from "../../field";
 import { useInput, useInputButton, useInputIcon, wrappedInputPropsAdapter } from "../../input";
 import { useToolbarProps } from "../../toolbar";
@@ -35,9 +35,10 @@ export interface InnerTextInputProps extends DomProps, InteractionStatesProps {
     /**
      * Called when the input value change.
      * @param {ChangeEvent} event - React's original synthetic event.
+     * @param {string} value - The input value.
      * @returns {void}
      */
-    onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+    onChange?: (event: ChangeEvent<HTMLInputElement>, value: string) => void;
     /**
      * The type of the input. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).
      */
@@ -91,6 +92,7 @@ export function InnerTextInput(props: InnerTextInputProps) {
         placeholder,
         required,
         validationState,
+        onChange,
         type = "text",
         autoFocus,
         icon,
@@ -115,7 +117,13 @@ export function InnerTextInput(props: InnerTextInputProps) {
     const [inputValue, setValue] = useControllableState(value, defaultValue, "");
 
     const handleChange = useEventCallback((event: ChangeEvent<HTMLInputElement>) => {
-        setValue(event.target.value);
+        const newValue = event.target.value;
+
+        if (!isNil(onChange)) {
+            onChange(event, newValue);
+        }
+
+        setValue(newValue);
     });
 
     const { wrapperProps, inputProps } = useInput({

--- a/packages/react-components/src/text-input/tests/jest/TextInput.test.jsx
+++ b/packages/react-components/src/text-input/tests/jest/TextInput.test.jsx
@@ -1,8 +1,23 @@
 import { TextInput } from "@react-components/text-input";
 import { act, render, waitFor } from "@testing-library/react";
 import { createRef } from "react";
+import userEvent from "@testing-library/user-event";
 
 // ***** Api *****
+
+test("call onChange when the value change", async () => {
+    const handler = jest.fn();
+
+    const { getByTestId } = render(
+        <TextInput onChange={handler} data-testid="input" />
+    );
+
+    act(() => {
+        userEvent.type(getByTestId("input"), "a");
+    });
+
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), "a"));
+});
 
 test("can focus the input with the focus api", async () => {
     let refNode = null;


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Issue: https://github.com/gsoft-inc/sg-orbit/issues/580

## What I did

- Added an extra arg for the input value to the onChange callback of every input components
- Normalize NumberInput clamp behavior to match the DateInput clamp behavior.
- Improve NumberInput test coverage

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes

- Does this need an update to the documentation? Yes

If your answer is yes to any of these, please make sure to include it in your PR.
