### PR TITLE
underline solid is now the default behaviour of a TextLink

### DIFF
--- a/packages/react-components/src/link/src/Link.css
+++ b/packages/react-components/src/link/src/Link.css
@@ -5,6 +5,7 @@
     padding: 0;
     position: relative;
     color: inherit;
+    /* direct text is responsible of setting the text decoration style */
     text-decoration: none;
 }
 
@@ -136,6 +137,11 @@
 }
 
 /* TEXT | VARIATIONS */
+/* TEXT | VARIATIONS | UNDERLINE | NONE */
+.o-ui-link-underline-none {
+    text-decoration: none;
+}
+
 /* TEXT | VARIATIONS | UNDERLINE | DOTTED */
 .o-ui-link-dotted .o-ui-link-text {
     text-decoration: underline;

--- a/packages/react-components/src/link/src/Link.css
+++ b/packages/react-components/src/link/src/Link.css
@@ -138,7 +138,7 @@
 
 /* TEXT | VARIATIONS */
 /* TEXT | VARIATIONS | UNDERLINE | NONE */
-.o-ui-link-underline-none {
+.o-ui-link-no-underline {
     text-decoration: none;
 }
 

--- a/packages/react-components/src/link/src/Link.css
+++ b/packages/react-components/src/link/src/Link.css
@@ -118,13 +118,13 @@
 /* TEXT | STATE | DISABLED | HOVER */
 .o-ui-link[disabled]:hover .o-ui-link-text,
 .o-ui-link[disabled].o-ui-link-hover .o-ui-link-text {
-    text-decoration: none;
+    text-decoration: underline;
 }
 
 /* TEXT | STATE | DISABLED | FOCUS */
 .o-ui-link[disabled]:focus .o-ui-link-text,
 .o-ui-link[disabled].o-ui-link-focus .o-ui-link-text {
-    text-decoration: none;
+    text-decoration: underline;
 }
 
 /* TEXT | STATE | ACTIVE | FOCUS */

--- a/packages/react-components/src/link/src/TextLink.tsx
+++ b/packages/react-components/src/link/src/TextLink.tsx
@@ -27,7 +27,7 @@ export interface InnerTextLinkProps {
     /**
      * The underline style.
      */
-    underline?: "solid" | "dotted";
+    underline?: "solid" | "dotted" | "none";
     /**
      * Whether or not this is an external link.
      */
@@ -66,7 +66,7 @@ export function InnerTextLink(props: InnerTextLinkProps) {
         target,
         rel,
         color,
-        underline,
+        underline = "solid",
         external,
         autoFocus,
         size,

--- a/packages/react-components/src/link/src/useLink.ts
+++ b/packages/react-components/src/link/src/useLink.ts
@@ -44,7 +44,7 @@ export function useLink({
             cssModule(
                 "o-ui-link",
                 color === "inherit" ? "inherit-color" : color,
-                underline,
+                underline === "none" ? "underline-none" : underline,
                 shape,
                 active && "active",
                 focus && "focus",

--- a/packages/react-components/src/link/src/useLink.ts
+++ b/packages/react-components/src/link/src/useLink.ts
@@ -44,7 +44,7 @@ export function useLink({
             cssModule(
                 "o-ui-link",
                 color === "inherit" ? "inherit-color" : color,
-                underline === "none" ? "underline-none" : underline,
+                underline === "none" ? "no-underline" : underline,
                 shape,
                 active && "active",
                 focus && "focus",

--- a/packages/react-components/src/link/tests/chromatic/createTextLinkTestSuite.jsx
+++ b/packages/react-components/src/link/tests/chromatic/createTextLinkTestSuite.jsx
@@ -120,7 +120,12 @@ export function createTextLinkTestSuite(element, stories) {
                 </div>
             </Stack>
         )
-        .add("dotted", () =>
+        .add("solid", () =>
+            <Inline verticalAlign="end">
+                <TextLink underline="solid" size="sm" href="#" element={element}>Flight details</TextLink>
+                <TextLink underline="solid" href="#" element={element}>Flight details</TextLink>
+            </Inline>
+        ).add("dotted", () =>
             <Inline verticalAlign="end">
                 <TextLink underline="dotted" size="sm" href="#" element={element}>Flight details</TextLink>
                 <TextLink underline="dotted" href="#" element={element}>Flight details</TextLink>

--- a/packages/react-components/src/link/tests/chromatic/createTextLinkTestSuite.jsx
+++ b/packages/react-components/src/link/tests/chromatic/createTextLinkTestSuite.jsx
@@ -120,16 +120,15 @@ export function createTextLinkTestSuite(element, stories) {
                 </div>
             </Stack>
         )
-        .add("solid", () =>
-            <Inline verticalAlign="end">
-                <TextLink underline="solid" size="sm" href="#" element={element}>Flight details</TextLink>
-                <TextLink underline="solid" href="#" element={element}>Flight details</TextLink>
-            </Inline>
-        )
         .add("dotted", () =>
             <Inline verticalAlign="end">
                 <TextLink underline="dotted" size="sm" href="#" element={element}>Flight details</TextLink>
                 <TextLink underline="dotted" href="#" element={element}>Flight details</TextLink>
+            </Inline>
+        ).add("none", () =>
+            <Inline verticalAlign="end">
+                <TextLink underline="none" size="sm" href="#" element={element}>Flight details</TextLink>
+                <TextLink underline="none" href="#" element={element}>Flight details</TextLink>
             </Inline>
         )
         .add("states", () =>


### PR DESCRIPTION
Issue: 

This PR fixes the issue https://github.com/gsoft-inc/sg-orbit/issues/599

## Summary

TextLinks were not accessible since there was no way to tell a link was a link visually before hovering it.

## What I did

the underline prop now defaults to solid, none is now an accepted value for the underline prop. 

## How to test

/?path=/story/chromatic-textlink--default