### PR TITLE
Render tooltip when trigger is disabled

### DIFF
--- a/packages/react-components/src/overlay/src/usePopup.ts
+++ b/packages/react-components/src/overlay/src/usePopup.ts
@@ -86,7 +86,7 @@ export function usePopup(type: "menu" | "listbox" | "dialog", {
                 updateIsOpen(event, false);
             }
         }),
-        hideOnLeave: isOpen && hideOnLeave,
+        hideOnLeave,
         isDisabled: disabled
     });
 
@@ -106,9 +106,9 @@ export function usePopup(type: "menu" | "listbox" | "dialog", {
         onHide: useEventCallback((event: SyntheticEvent) => {
             updateIsOpen(event, false);
         }),
-        hideOnEscape: isOpen && hideOnEscape,
-        hideOnLeave: isOpen && hideOnLeave,
-        hideOnOutsideClick: isOpen && hideOnOutsideClick
+        hideOnEscape,
+        hideOnLeave,
+        hideOnOutsideClick
     });
 
     const restoreFocusProps = useRestoreFocus(focusScope, { isDisabled: !restoreFocus || !isOpen });

--- a/packages/react-components/src/overlay/tests/jest/usePopup.test.jsx
+++ b/packages/react-components/src/overlay/tests/jest/usePopup.test.jsx
@@ -157,12 +157,15 @@ describe("\"click\" trigger", () => {
     test("when opened, close on trigger click", async () => {
         const { getByTestId, queryByTestId } = render(
             <Popup
-                defaultOpen
                 trigger="click"
                 data-triggertestid="trigger"
                 data-overlaytestid="overlay"
             />
         );
+
+        act(() => {
+            userEvent.click(getByTestId("trigger"));
+        });
 
         await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
@@ -176,11 +179,15 @@ describe("\"click\" trigger", () => {
     test("when opened, close on esc keypress", async () => {
         const { getByTestId, queryByTestId } = render(
             <Popup
-                defaultOpen
                 trigger="click"
+                data-triggertestid="trigger"
                 data-overlaytestid="overlay"
             />
         );
+
+        act(() => {
+            userEvent.click(getByTestId("trigger"));
+        });
 
         await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
@@ -199,11 +206,15 @@ describe("\"click\" trigger", () => {
         const { getByTestId } = render(
             <Popup
                 hideOnEscape={false}
-                defaultOpen
                 trigger="click"
+                data-triggertestid="trigger"
                 data-overlaytestid="overlay"
             />
         );
+
+        act(() => {
+            userEvent.click(getByTestId("trigger"));
+        });
 
         await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
@@ -223,12 +234,16 @@ describe("\"click\" trigger", () => {
             <>
                 <button type="button" data-testid="focusable-element">Focusable element</button>
                 <Popup
-                    defaultOpen
                     trigger="click"
+                    data-triggertestid="trigger"
                     data-overlaytestid="overlay"
                 />
             </>
         );
+
+        act(() => {
+            userEvent.click(getByTestId("trigger"));
+        });
 
         await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
@@ -249,12 +264,16 @@ describe("\"click\" trigger", () => {
                 <button type="button" data-testid="focusable-element">Focusable element</button>
                 <Popup
                     hideOnLeave={false}
-                    defaultOpen
                     trigger="click"
+                    data-triggertestid="trigger"
                     data-overlaytestid="overlay"
                 />
             </>
         );
+
+        act(() => {
+            userEvent.click(getByTestId("trigger"));
+        });
 
         await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
@@ -272,11 +291,15 @@ describe("\"click\" trigger", () => {
     test("when opened, close on outside click", async () => {
         const { getByTestId, queryByTestId } = render(
             <Popup
-                defaultOpen
                 trigger="click"
+                data-triggertestid="trigger"
                 data-overlaytestid="overlay"
             />
         );
+
+        act(() => {
+            userEvent.click(getByTestId("trigger"));
+        });
 
         await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
@@ -295,11 +318,15 @@ describe("\"click\" trigger", () => {
         const { getByTestId } = render(
             <Popup
                 hideOnOutsideClick={false}
-                defaultOpen
                 trigger="click"
+                data-triggertestid="trigger"
                 data-overlaytestid="overlay"
             />
         );
+
+        act(() => {
+            userEvent.click(getByTestId("trigger"));
+        });
 
         await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
@@ -356,10 +383,14 @@ describe("\"hover\" trigger", () => {
         const { getByTestId, queryByTestId } = render(
             <Popup
                 trigger="hover"
-                defaultOpen
+                data-triggertestid="trigger"
                 data-overlaytestid="overlay"
             />
         );
+
+        act(() => {
+            fireEvent.mouseEnter(getByTestId("trigger"));
+        });
 
         await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
@@ -440,11 +471,14 @@ describe("\"hover\" trigger", () => {
         const { getByTestId, queryByTestId } = render(
             <Popup
                 trigger="hover"
-                defaultOpen
                 data-triggertestid="trigger"
                 data-overlaytestid="overlay"
             />
         );
+
+        act(() => {
+            fireEvent.mouseEnter(getByTestId("trigger"));
+        });
 
         await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
@@ -460,11 +494,14 @@ describe("\"hover\" trigger", () => {
             <Popup
                 hideOnLeave={false}
                 trigger="hover"
-                defaultOpen
                 data-triggertestid="trigger"
                 data-overlaytestid="overlay"
             />
         );
+
+        act(() => {
+            fireEvent.mouseEnter(getByTestId("trigger"));
+        });
 
         await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
@@ -479,10 +516,14 @@ describe("\"hover\" trigger", () => {
         const { getByTestId, queryByTestId } = render(
             <Popup
                 trigger="hover"
-                defaultOpen
+                data-triggertestid="trigger"
                 data-overlaytestid="overlay"
             />
         );
+
+        act(() => {
+            fireEvent.mouseEnter(getByTestId("trigger"));
+        });
 
         await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
@@ -502,10 +543,14 @@ describe("\"hover\" trigger", () => {
             <Popup
                 hideOnOutsideClick={false}
                 trigger="hover"
-                defaultOpen
+                data-triggertestid="trigger"
                 data-overlaytestid="overlay"
             />
         );
+
+        act(() => {
+            fireEvent.mouseEnter(getByTestId("trigger"));
+        });
 
         await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
@@ -617,10 +662,14 @@ test("when autoFocus is true, focus the popup element on open", async () => {
     const { getByTestId } = render(
         <Popup
             autoFocus
-            defaultOpen
+            data-triggertestid="trigger"
             data-overlaytestid="overlay"
         />
     );
+
+    act(() => {
+        userEvent.click(getByTestId("trigger"));
+    });
 
     await waitFor(() => expect(getByTestId("overlay")).toHaveFocus());
 });

--- a/packages/react-components/src/tooltip/src/Tooltip.css
+++ b/packages/react-components/src/tooltip/src/Tooltip.css
@@ -17,3 +17,8 @@
 .o-ui-tooltip .o-ui-text + .o-ui-icon  {
     margin-left: var(--o-ui-global-scale-alpha);
 }
+
+/* DISABLED WRAPPER */
+.o-ui-tooltip-disabled-wrapper {
+    display: inline-block;
+}

--- a/packages/react-components/src/tooltip/src/TooltipTrigger.tsx
+++ b/packages/react-components/src/tooltip/src/TooltipTrigger.tsx
@@ -153,18 +153,20 @@ export function InnerTooltipTrigger({
 
     const tooltipId = useId(tooltip.props.id, "o-ui-tooltip");
 
+    const triggerWithDescribedBy = augmentElement(trigger, {
+        "aria-describedby": isOpen ? tooltipId : undefined
+    });
+
     // HACK: a disabled element doesn't fire event, therefore the element is wrapped in a div.
-    const triggerElement = !trigger.props.disabled ? trigger : (
+    const triggerElement = !triggerWithDescribedBy.props.disabled ? triggerWithDescribedBy : (
         <div className="o-ui-tooltip-disabled-wrapper">
-            {trigger}
+            {triggerWithDescribedBy}
         </div>
     );
 
-    // TODO: move aria-describedby on the button when there is a wrapper?
     const triggerMarkup = augmentElement(triggerElement, mergeProps(
         triggerProps,
         {
-            "aria-describedby": isOpen ? tooltipId : undefined,
             ref: triggerRef
         }
     ));

--- a/packages/react-components/src/tooltip/src/TooltipTrigger.tsx
+++ b/packages/react-components/src/tooltip/src/TooltipTrigger.tsx
@@ -33,7 +33,6 @@ interface InnerTooltipTriggerProps {
     | "left"
     | "left-start"
     | "left-end";
-
     /**
      * Called when the open state change.
      * @param {SyntheticEvent} event - React's original SyntheticEvent.
@@ -74,7 +73,6 @@ interface InnerTooltipTriggerProps {
      */
     forwardedRef: ForwardedRef<any>;
 }
-
 
 export function parseTooltipTrigger(children: ReactNode) {
     const array = Children.toArray(resolveChildren(children));
@@ -155,7 +153,15 @@ export function InnerTooltipTrigger({
 
     const tooltipId = useId(tooltip.props.id, "o-ui-tooltip");
 
-    const triggerMarkup = augmentElement(trigger, mergeProps(
+    // HACK: a disabled element doesn't fire event, therefore the element is wrapped in a div.
+    const triggerElement = !trigger.props.disabled ? trigger : (
+        <div className="o-ui-tooltip-disabled-wrapper">
+            {trigger}
+        </div>
+    );
+
+    // TODO: move aria-describedby on the button when there is a wrapper?
+    const triggerMarkup = augmentElement(triggerElement, mergeProps(
         triggerProps,
         {
             "aria-describedby": isOpen ? tooltipId : undefined,

--- a/packages/react-components/src/tooltip/tests/chromatic/Tooltip.chroma.jsx
+++ b/packages/react-components/src/tooltip/tests/chromatic/Tooltip.chroma.jsx
@@ -21,6 +21,12 @@ function stories(segment) {
 }
 
 stories()
+    .add("test", () =>
+        <TooltipTrigger>
+            <Button disabled>Trigger</Button>
+            <Tooltip>Man must rise above the Earth</Tooltip>
+        </TooltipTrigger>
+    )
     .add("default", () =>
         <TooltipTrigger>
             <Button>Trigger</Button>

--- a/packages/react-components/src/tooltip/tests/jest/TooltipTrigger.test.jsx
+++ b/packages/react-components/src/tooltip/tests/jest/TooltipTrigger.test.jsx
@@ -1,12 +1,52 @@
 import { Button } from "@react-components/button";
 import { Tooltip, TooltipTrigger } from "@react-components/tooltip";
 import { Transition } from "@react-components/transition";
-import { act, render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import { createRef } from "react";
 import userEvent from "@testing-library/user-event";
 
 beforeAll(() => {
     Transition.disableAnimation = true;
+});
+
+// ***** Behaviors *****
+
+test("when the trigger is disabled, open on trigger hover", async () => {
+    const { getByTestId } = render(
+        <TooltipTrigger>
+            <Button disabled data-testid="trigger">Trigger</Button>
+            <Tooltip data-testid="tooltip">Content</Tooltip>
+        </TooltipTrigger>
+    );
+
+    act(() => {
+        // userEvent.hover() doesn't fire when the element is disabled.
+        fireEvent.mouseEnter(getByTestId("trigger"));
+    });
+
+    await waitFor(() => expect(getByTestId("tooltip")).toBeInTheDocument());
+});
+
+test("when the trigger is disabled, close on trigger leave", async () => {
+    const { getByTestId, queryByTestId } = render(
+        <TooltipTrigger>
+            <Button disabled data-testid="trigger">Trigger</Button>
+            <Tooltip data-testid="tooltip">Content</Tooltip>
+        </TooltipTrigger>
+    );
+
+    act(() => {
+        // userEvent.hover() doesn't fire when the element is disabled.
+        fireEvent.mouseEnter(getByTestId("trigger"));
+    });
+
+    await waitFor(() => expect(getByTestId("tooltip")).toBeInTheDocument());
+
+    act(() => {
+        fireEvent.mouseLeave(getByTestId("trigger").parentElement);
+    });
+
+    await waitFor(() => expect(queryByTestId("tooltip")).not.toBeInTheDocument());
 });
 
 // ***** Aria *****
@@ -56,7 +96,7 @@ test("when a tooltip is visible, the tooltip trigger aria-describedby match the 
     await waitFor(() => expect(getByTestId("trigger")).toHaveAttribute("aria-describedby", "tooltip-id"));
 });
 
-// ***** Aria *****
+// ***** Api *****
 
 test("call onOpenChange when the tooltip appears", async () => {
     const handler = jest.fn();


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Issue: https://github.com/gsoft-inc/sg-orbit/issues/634

## Summary

- A disabled trigger is now wrapped inside a div to have access to a mouseEnter event.
- Since React doesn't fire a mouseLeave event for a div having a disabled element (https://github.com/facebook/react/issues/10396) the useOverlayTrigger hooks have been updated to hack our way around this limitation.

## How to test

- Is this testable with Jest or Chromatic screenshots?

- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.
