### PR TITLE
outline is now the focus state of links

### DIFF
--- a/packages/react-components/src/autocomplete/src/Autocomplete.css
+++ b/packages/react-components/src/autocomplete/src/Autocomplete.css
@@ -18,5 +18,4 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-
 }

--- a/packages/react-components/src/link/src/Link.css
+++ b/packages/react-components/src/link/src/Link.css
@@ -93,8 +93,6 @@
 .o-ui-text-link.o-ui-link-focus {
     outline: none;
     border-radius: var(--o-ui-shape-rounded);
-    background-color: rgba(0, 0, 0, 0.04);
-    box-shadow: 0 0 0 var(--o-ui-focus-ring-thickness-md) rgba(0, 0, 0, 0.04);
 }
 
 .o-ui-text-link:focus-visible:after,
@@ -186,13 +184,6 @@
     color: var(--o-ui-alias-text-primary-1-hover);
 }
 
-/* PRIMARY | STATE | FOCUS */
-.o-ui-link:focus-visible.o-ui-link-primary,
-.o-ui-link-focus.o-ui-link-primary {
-    background-color: var(--o-ui-alias-background-primary-1-focus);
-    box-shadow: 0 0 0 var(--o-ui-focus-ring-thickness-md) var(--o-ui-alias-background-primary-1-focus);
-}
-
 /* PRIMARY | STATE | ACTIVE */
 .o-ui-link:active.o-ui-link-primary,
 .o-ui-link-active.o-ui-link-primary {
@@ -201,7 +192,6 @@
 
 /* DANGER */
 .o-ui-link-danger {
-    --o-ui-focus-ring-color: var(--o-ui-border-negative-1-translucent);
     color: var(--o-ui-alias-text-negative-1);
 }
 
@@ -209,13 +199,6 @@
 .o-ui-link:hover.o-ui-link-danger,
 .o-ui-link-hover.o-ui-link-danger {
     color: var(--o-ui-alias-text-negative-1-hover);
-}
-
-/* DANGER | STATE | FOCUS */
-.o-ui-link:focus-visible.o-ui-link-danger,
-.o-ui-link-focus.o-ui-link-danger {
-    background-color: var(--o-ui-alias-background-negative-2);
-    box-shadow: 0 0 0 var(--o-ui-focus-ring-thickness-md) var(--o-ui-alias-background-negative-2);
 }
 
 /* DANGER | STATE | ACTIVE */
@@ -233,13 +216,6 @@
 .o-ui-link:hover.o-ui-link-secondary,
 .o-ui-link-hover.o-ui-link-secondary {
     color: var(--o-ui-alias-text-3-hover);
-}
-
-/* SECONDARY | STATE | FOCUS */
-.o-ui-link:focus-visible.o-ui-link-secondary,
-.o-ui-link-focus.o-ui-link-secondary {
-    background-color: var(--o-ui-alias-background-3);
-    box-shadow: 0 0 0 var(--o-ui-focus-ring-thickness-md) var(--o-ui-alias-border-2);
 }
 
 /* SECONDARY | STATE | ACTIVE */

--- a/storybook/styles/docs.css
+++ b/storybook/styles/docs.css
@@ -211,6 +211,7 @@
 .sbdocs.sbdocs-a {
     font-size: var(--o-ui-global-type-scale-6);
     color: var(--o-ui-alias-primary-700) !important;
+    text-decoration: underline;
 }
 
 .sbdocs.sbdocs-a:hover,


### PR DESCRIPTION
Issue: 

#640 

## Summary

TextLink focus states were not following the logic of other components focus states. This PR aims to fix that.

## What I did

Added an outline to Textlinks instead of a background.

## How to test

/?path=/docs/link--color then focus on a link using `Tab`