### PR TITLE
Fix avatar initials issues

### DIFF
--- a/packages/react-components/src/avatar/src/Avatar.tsx
+++ b/packages/react-components/src/avatar/src/Avatar.tsx
@@ -1,12 +1,12 @@
 import "./Avatar.css";
 
+import { AriaLabelingProps, createSizeAdapter, cssModule, forwardRef, isNil, isNilOrEmpty, isString, mergeProps, normalizeSize, slot } from "../../shared";
 import { AsyncImage } from "../../image";
 import { Box } from "../../box";
 import { ComponentProps, ElementType, ForwardedRef, ReactNode, useMemo } from "react";
 import { Text } from "../../typography";
-import { createSizeAdapter, cssModule, forwardRef, isNil, isString, mergeProps, normalizeSize, slot } from "../../shared";
 
-export interface InnerAvatarProps {
+export interface InnerAvatarProps extends AriaLabelingProps {
     /**
      * The name of the person in the avatar.
      */
@@ -40,7 +40,9 @@ export interface InnerAvatarProps {
 function AvatarImage({
     name,
     src,
-    retryCount
+    retryCount,
+    size,
+    "aria-label": ariaLabel
 }: Partial<AvatarProps>) {
     if (!isString(src)) {
         return (
@@ -56,7 +58,11 @@ function AvatarImage({
             retryCount={retryCount}
             className="o-ui-avatar-image"
         >
-            <AvatarInitials name={name} />
+            <AvatarInitials
+                name={name}
+                size={size}
+                aria-label={ariaLabel}
+            />
         </AsyncImage>
     );
 }
@@ -78,7 +84,7 @@ const O365InitialsColorsForName = [
     "#B91D47"
 ];
 
-function AvatarInitials({ name, size }: Partial<AvatarProps>) {
+function AvatarInitials({ name, size, "aria-label": ariaLabel }: Partial<AvatarProps>) {
     const initials = useMemo(() => {
         const cleanName = name.replace(/\s+/g, " ").trim();
 
@@ -109,7 +115,7 @@ function AvatarInitials({ name, size }: Partial<AvatarProps>) {
                 backgroundColor: color
             }}
             role="img"
-            aria-label={name}
+            aria-label={ariaLabel ?? name}
         >
             {initials}
         </AvatarText>
@@ -157,21 +163,25 @@ export function InnerAvatar({
     src,
     retryCount,
     size,
+    "aria-label": ariaLabel,
     as = "div",
     forwardedRef,
     ...rest
 }: InnerAvatarProps) {
-    const content = !isNil(src)
+    const content = !isNilOrEmpty(src)
         ? (
             <AvatarImage
                 name={name}
                 src={src}
                 retryCount={retryCount}
+                size={size}
+                aria-label={ariaLabel}
             />
         ) : (
             <AvatarInitials
                 name={name}
                 size={size}
+                aria-label={ariaLabel}
             />
         );
 

--- a/packages/react-components/src/avatar/tests/chromatic/Avatar.chroma.jsx
+++ b/packages/react-components/src/avatar/tests/chromatic/Avatar.chroma.jsx
@@ -31,15 +31,23 @@ stories()
         </Inline>
     )
     .add("remote image", () =>
-        <Inline>
-            <Avatar size="2xl" name="Neil Armstrong" src="https://randomuser.me/api/portraits/men/10.jpg" />
-            <Avatar size="2xl" name="Neil Armstrong" src="https://randomuser.me" />
-        </Inline>,
+        <Avatar size="2xl" name="Neil Armstrong" src="https://randomuser.me/api/portraits/men/10.jpg" />,
          {
              ...paramsBuilder()
                  .chromaticDelay(500)
                  .build()
          }
+    )
+    .add("failing remote src", () =>
+        <Inline verticalAlign="center">
+            <Avatar size="2xs" src="https://www.google.com" name="Neil Armstrong" />
+            <Avatar size="xs" src="https://www.google.com" name="Neil Armstrong" />
+            <Avatar size="sm" src="https://www.google.com" name="Neil Armstrong" />
+            <Avatar src="https://www.google.com" name="Neil Armstrong" />
+            <Avatar size="lg" src="https://www.google.com" name="Neil Armstrong" />
+            <Avatar size="xl" src="https://www.google.com" name="Neil Armstrong" />
+            <Avatar size="2xl" src="https://www.google.com" name="Neil Armstrong" />
+        </Inline>
     )
     .add("initials", () =>
         <Stack>
@@ -60,8 +68,16 @@ stories()
             </Inline>
         </Stack>
     )
-    .add("failing remote src", () =>
-        <Avatar src="https://www.google.com" name="Neil Armstrong" />
+    .add("empty src", () =>
+        <Inline verticalAlign="center">
+            <Avatar src="" size="2xs" name="Neil Armstrong" />
+            <Avatar src="" size="xs" name="Neil Armstrong" />
+            <Avatar src="" size="sm" name="Neil Armstrong" />
+            <Avatar src="" name="Neil Armstrong" />
+            <Avatar src="" size="lg" name="Neil Armstrong" />
+            <Avatar src="" size="xl" name="Neil Armstrong" />
+            <Avatar src="" size="2xl" name="Neil Armstrong" />
+        </Inline>
     )
     .add("styling", () =>
         <Inline>

--- a/packages/react-components/src/avatar/tests/jest/Avatar.test.jsx
+++ b/packages/react-components/src/avatar/tests/jest/Avatar.test.jsx
@@ -2,6 +2,24 @@ import { Avatar } from "@react-components/avatar";
 import { createRef } from "react";
 import { render, waitFor } from "@testing-library/react";
 
+// ***** Aria *****
+
+test("when no image src is provided and a custom aria-label is provided, the aria-label attribute match the provided aria-label", async () => {
+    const { getByLabelText } = render(
+        <Avatar name="Elon Musk" aria-label="Maye Musk" />
+    );
+
+    await waitFor(() => expect(getByLabelText("Maye Musk")).not.toBeNull());
+});
+
+test("when an image src is provided and a custom aria-label is provided, the aria-label attribute match the provided aria-label", async () => {
+    const { getByLabelText } = render(
+        <Avatar src="dummy" name="Elon Musk" aria-label="Maye Musk" />
+    );
+
+    await waitFor(() => expect(getByLabelText("Maye Musk")).not.toBeNull());
+});
+
 // ***** Refs *****
 
 test("ref is a DOM element", async () => {


### PR DESCRIPTION

<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Issue: https://github.com/gsoft-inc/sg-orbit/issues/694

## What I did

- aria-label is now forwarded to the initials element instead of being rendered on the outer contained
- a custom aria-label prop will superceed the name prop
- the size is now properly forwarded to the initials component when used as a fallback to a failing remote image src

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes

- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.
