### PR TITLE
Updated image component api to have an optionnal src or srcset

### DIFF
--- a/packages/react-components/src/image/src/Image.tsx
+++ b/packages/react-components/src/image/src/Image.tsx
@@ -7,7 +7,11 @@ export interface InnerImageProps {
     /**
      * The path to the image.
      */
-    src: string;
+    src?: string;
+    /**
+     * One or more strings separated by commas, indicating possible image sources for the user agent to use. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-srcset).
+     */
+    srcSet?: string;
     /**
      * A text description of the image.
      */


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Issue: https://github.com/gsoft-inc/sg-orbit/issues/697

## What I did

- Image component `src` prop is now optionnal
- Added `srcSet` prop to the Image component docs

## How to test

- Is this testable with Jest or Chromatic screenshots? No

- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.
