### PR TITLE
Add Accessibility blurb to Alert Story in Storybook

### DIFF
--- a/packages/react-components/src/alert/docs/Alert.stories.mdx
+++ b/packages/react-components/src/alert/docs/Alert.stories.mdx
@@ -26,7 +26,7 @@ import { Heading, InnerHeading } from "@react-components/typography";
 
 An alert comes with the `alertdialog` role and should only be used when an alert, error, or warning occurs.
 
-- This role requires an accessible name (through `aria-labelledby` provided by the `<Heading>` element), and an accessible description (using `aria-discribedby` provided by the `<Content>` element).
+- This role requires an accessible name (through `aria-labelledby` provided by the `<Heading>` element), and an accessible description (using `aria-describedby` provided by the `<Content>` element).
 - Alert dialog must have at least one focusable control and focus must be moved to that control when the alert dialog appears. Generally alert dialogs have at least a Confirmation, Close or Cancel button that can be used to move focus to.
 - The tab order inside the alert dialog must wrap.
 

--- a/packages/react-components/src/alert/docs/Alert.stories.mdx
+++ b/packages/react-components/src/alert/docs/Alert.stories.mdx
@@ -32,9 +32,12 @@ It requires:
 
 Label and description can be overwritten with the use of `aria-label` and `aria-describedby` props on the alert.
 
+### Focus
+
 If the alert calls for an action, make sure to set the focus correctly to avoid any unwanted action.
 To do so, you can use the `autoFocusButton` prop on the alert to specify which control should have the initial focus.
-For example, if your alert is destructive, you can offer a secondary button _Cancel_ and set the focus to it with `autoFocusButton="seconday"`.
+
+If your alert is destructive, you can offer a secondary button _Cancel_ and set the focus to it with `autoFocusButton="seconday"`.
 
 ## Usage
 

--- a/packages/react-components/src/alert/docs/Alert.stories.mdx
+++ b/packages/react-components/src/alert/docs/Alert.stories.mdx
@@ -20,6 +20,18 @@ import { Heading, InnerHeading } from "@react-components/typography";
     githubPath="/packages/react-components/src/alert/src"
 />
 
+## Guidelines
+
+### Accessibility
+
+An alert comes with the `alertdialog` role and should only be used when an alert, error, or warning occurs.
+
+- This role requires an accessible name (through `aria-labelledby` provided by the `<Heading>` element), and an accessible description (using `aria-discribedby` provided by the `<Content>` element).
+- Alert dialog must have at least one focusable control and focus must be moved to that control when the alert dialog appears. Generally alert dialogs have at least a Confirmation, Close or Cancel button that can be used to move focus to.
+- The tab order inside the alert dialog must wrap.
+
+When the _alert dialog_ is correctly labeled and focus is moved to a control inside the dialog, screen readers should announce the dialog's accessible role, name and optionally description before announcing the focused element.
+
 ## Usage
 
 ### Default

--- a/packages/react-components/src/alert/docs/Alert.stories.mdx
+++ b/packages/react-components/src/alert/docs/Alert.stories.mdx
@@ -22,14 +22,15 @@ import { Heading, InnerHeading } from "@react-components/typography";
 
 ## Accessibility
 
-An alert comes with the `alertdialog` role and should be used to display a confirmation message, an alert, error, or warning.
+An alert comes with the `alertdialog` role and should be used to display a confirmation message, an alert, an error, or a warning.
 
 It requires:
-- The focus to be trapped inside the Alert.
+- The focus to be trapped inside the alert.
+- A control focused when the dialog appears, provided by the `primaryButtonLabel` prop. To specify which button should be focused, use the `autoFocusButton` prop.
 - A label, provided by the `<Heading>`.
-- Optionally, A description, provided by the `<Content>`.
+- A description, provided by the `<Content>`.
 
-Label and Description can be overwritten with the use of `aria-label` and `aria-describedby` on the Alert component.
+Label and description can be overwritten with the use of `aria-label` and `aria-describedby` props on the alert.
 
 ## Usage
 

--- a/packages/react-components/src/alert/docs/Alert.stories.mdx
+++ b/packages/react-components/src/alert/docs/Alert.stories.mdx
@@ -26,11 +26,15 @@ An alert comes with the `alertdialog` role and should be used to display a confi
 
 It requires:
 - The focus to be trapped inside the alert.
-- A control focused when the dialog appears, provided by the `primaryButtonLabel` prop. To specify which button should be focused, use the `autoFocusButton` prop.
+- A control focused when the dialog appears, provided by the `primaryButtonLabel` prop.
 - A label, provided by the `<Heading>`.
 - A description, provided by the `<Content>`.
 
 Label and description can be overwritten with the use of `aria-label` and `aria-describedby` props on the alert.
+
+If the alert calls for an action, make sure to set the focus correctly to avoid any unwanted action.
+To do so, you can use the `autoFocusButton` prop on the alert to specify which control should have the initial focus.
+For example, if your alert is destructive, you can offer a secondary button _Cancel_ and set the focus to it with `autoFocusButton="seconday"`.
 
 ## Usage
 

--- a/packages/react-components/src/alert/docs/Alert.stories.mdx
+++ b/packages/react-components/src/alert/docs/Alert.stories.mdx
@@ -20,17 +20,16 @@ import { Heading, InnerHeading } from "@react-components/typography";
     githubPath="/packages/react-components/src/alert/src"
 />
 
-## Guidelines
+## Accessibility
 
-### Accessibility
+An alert comes with the `alertdialog` role and should be used to display a confirmation message, an alert, error, or warning.
 
-An alert comes with the `alertdialog` role and should only be used when an alert, error, or warning occurs.
+It requires:
+- The focus to be trapped inside the Alert.
+- A label, provided by the `<Heading>`.
+- Optionally, A description, provided by the `<Content>`.
 
-- This role requires an accessible name (through `aria-labelledby` provided by the `<Heading>` element), and an accessible description (using `aria-describedby` provided by the `<Content>` element).
-- Alert dialog must have at least one focusable control and focus must be moved to that control when the alert dialog appears. Generally alert dialogs have at least a Confirmation, Close or Cancel button that can be used to move focus to.
-- The tab order inside the alert dialog must wrap.
-
-When the _alert dialog_ is correctly labeled and focus is moved to a control inside the dialog, screen readers should announce the dialog's accessible role, name and optionally description before announcing the focused element.
+Label and Description can be overwritten with the use of `aria-label` and `aria-describedby` on the Alert component.
 
 ## Usage
 

--- a/packages/react-components/src/dialog/src/Dialog.tsx
+++ b/packages/react-components/src/dialog/src/Dialog.tsx
@@ -26,7 +26,6 @@ import { ComponentProps, ElementType, ForwardedRef, MouseEvent, ReactNode, clone
 import { CrossButton } from "../../button";
 import { Text } from "../../typography";
 import { Underlay, useOverlayFocusRing, useRestoreFocus, useTrapFocus } from "../../overlay";
-import { is } from "date-fns/locale";
 import { useDialogTriggerContext } from "./DialogTriggerContext";
 
 export interface InnerDialogProps extends DomProps, AriaLabelingProps, InteractionStatesProps {
@@ -132,6 +131,7 @@ export function InnerDialog({
     zIndex = 1,
     "aria-label": ariaLabel,
     "aria-labelledby": ariaLabelledBy,
+    "aria-describedby": ariaDescribedBy,
     wrapperProps,
     as = "section",
     children,
@@ -307,7 +307,7 @@ export function InnerDialog({
                             "aria-modal": true,
                             "aria-label": ariaLabel,
                             "aria-labelledby": isNil(ariaLabel) ? ariaLabelledBy ?? headingId : undefined,
-                            "aria-describedby": contentId,
+                            "aria-describedby": !isNil(ariaDescribedBy) ? ariaDescribedBy : contentId ?? undefined,
                             as,
                             ref: dialogRef
                         },

--- a/packages/react-components/src/dialog/src/Dialog.tsx
+++ b/packages/react-components/src/dialog/src/Dialog.tsx
@@ -26,6 +26,7 @@ import { ComponentProps, ElementType, ForwardedRef, MouseEvent, ReactNode, clone
 import { CrossButton } from "../../button";
 import { Text } from "../../typography";
 import { Underlay, useOverlayFocusRing, useRestoreFocus, useTrapFocus } from "../../overlay";
+import { is } from "date-fns/locale";
 import { useDialogTriggerContext } from "./DialogTriggerContext";
 
 export interface InnerDialogProps extends DomProps, AriaLabelingProps, InteractionStatesProps {
@@ -213,6 +214,7 @@ export function InnerDialog({
             as: "header"
         },
         content: {
+            id: `${dialogId}-content`,
             className: "o-ui-dialog-content",
             as: Text
         },
@@ -229,6 +231,8 @@ export function InnerDialog({
     }), [dialogId]));
 
     const headingId = heading?.props?.id;
+
+    const contentId = content?.props?.id;
 
     const imageMarkup = image && (
         <Box className="o-ui-dialog-image">
@@ -303,6 +307,7 @@ export function InnerDialog({
                             "aria-modal": true,
                             "aria-label": ariaLabel,
                             "aria-labelledby": isNil(ariaLabel) ? ariaLabelledBy ?? headingId : undefined,
+                            "aria-describedby": contentId,
                             as,
                             ref: dialogRef
                         },

--- a/packages/react-components/src/dialog/tests/jest/Dialog.test.jsx
+++ b/packages/react-components/src/dialog/tests/jest/Dialog.test.jsx
@@ -169,6 +169,28 @@ test("when no aria-label or aria-labelledby attributes are provided, the dialog 
     await waitFor(() => expect(getByTestId("dialog")).toHaveAttribute("aria-labelledby", "heading-1"));
 });
 
+test("when an aria-describedby attribute is provided, the dialog aria-describedby attribute value match the provided value", async () => {
+    const { getByTestId } = render(
+        <Dialog aria-describedby="content-1" data-testid="dialog">
+            <Heading>Iconic Arecibo Observatory collapses</Heading>
+            <Content>This year, the National Science Foundation (NSF) said farewell to the iconic Arecibo Observatory in Puerto Rico after two major cable failures led to the radio telescope's collapse.</Content>
+        </Dialog>
+    );
+
+    await waitFor(() => expect(getByTestId("dialog")).toHaveAttribute("aria-describedby", "content-1"));
+});
+
+test("when no aria-describedby attributes is provided, the dialog aria-describedby attribute value match the content id", async () => {
+    const { getByTestId } = render(
+        <Dialog data-testid="dialog">
+            <Heading>Iconic Arecibo Observatory collapses</Heading>
+            <Content id="content-1">This year, the National Science Foundation (NSF) said farewell to the iconic Arecibo Observatory in Puerto Rico after two major cable failures led to the radio telescope's collapse.</Content>
+        </Dialog>
+    );
+
+    await waitFor(() => expect(getByTestId("dialog")).toHaveAttribute("aria-describedby", "content-1"));
+});
+
 // ***** Ref *****
 
 test("ref is a DOM element", async () => {


### PR DESCRIPTION
Issue: 

## Summary

The goal of this PR is to add a short blurb about the Accessibility implications of the Alert component in Orbit.

## What I did

- Added documentations around the `alertdialog` role
- Added the logic to support `aria-describedby` in Dialog
- Added tests to cover the added logic.

## How to test

Added documentation:
![image](https://user-images.githubusercontent.com/234418/128036175-8f839ff4-11a2-444a-823c-1ea94ba3f969.png)

Case with only Content:
![image](https://user-images.githubusercontent.com/234418/128035888-c9093f70-9a48-4d4a-ac4d-725ca6e42499.png)

Case with `aria-describedby` configured:
![image](https://user-images.githubusercontent.com/234418/128036043-b80f2cd1-0086-490b-bc51-b009cc9c38b2.png)
