### PR TITLE
function useId should have an optional userId 

### DIFF
--- a/packages/react-components/src/shared/src/useId.ts
+++ b/packages/react-components/src/shared/src/useId.ts
@@ -2,7 +2,7 @@ import { isNil } from "./assertions";
 import { useId as useAutoId } from "@reach/auto-id";
 
 // This utility will initially trigger a re-render.
-export function useId(userId: string, prefix?: string) {
+export function useId(userId?: string, prefix?: string) {
     const uuid = useAutoId();
 
     // Unfortunatelly, providing a user id to useAutoId, doesn't always works, sometimes the user id is ignored.


### PR DESCRIPTION
https://github.com/gsoft-inc/sg-orbit/issues/715


Modified the type of the userId provided to the useId function so it properly accepts the undefined value 