### PR TITLE
Fix Autocomplete spacing glitch

### DIFF
--- a/packages/components/src/collection/src/useScrollableCollection.ts
+++ b/packages/components/src/collection/src/useScrollableCollection.ts
@@ -1,3 +1,4 @@
+import { CollectionNode } from "@components/";
 import { RefObject, useLayoutEffect, useState } from "react";
 import { isNil } from "../../shared";
 
@@ -30,15 +31,16 @@ function getOuterHeight(element: HTMLElement) {
     return clientRect.height + toPixels(computedStyle.marginTop) + toPixels(computedStyle.marginBottom);
 }
 
-export function useScrollableCollection(containerRef: RefObject<Element>, {
-    borderHeight = 0,
-    disabled,
-    dividerSelector,
-    itemSelector,
-    maxHeight = 500,
-    paddingHeight = 0,
-    sectionSelector
-}: UseScrollableCollectionOptions = {}) {
+export function useScrollableCollection(containerRef: RefObject<Element>, nodes: CollectionNode[],
+    {
+        borderHeight = 0,
+        disabled,
+        dividerSelector,
+        itemSelector,
+        maxHeight = 500,
+        paddingHeight = 0,
+        sectionSelector
+    }: UseScrollableCollectionOptions = {}) {
     const [collectionHeight, setCollectionHeight] = useState<string>();
 
     useLayoutEffect(() => {
@@ -65,7 +67,8 @@ export function useScrollableCollection(containerRef: RefObject<Element>, {
                 setCollectionHeight(`${height}px`);
             }
         }
-    }, [containerRef, maxHeight, borderHeight, paddingHeight, itemSelector, sectionSelector, dividerSelector, disabled]);
+        // nodes must be in the dependency array in order to be able to recompute new element selected by the querySelectorAll
+    }, [containerRef, nodes, maxHeight, borderHeight, paddingHeight, itemSelector, sectionSelector, dividerSelector, disabled]);
 
     return isNil(collectionHeight) ? {} : {
         style: {

--- a/packages/components/src/collection/src/useScrollableCollection.ts
+++ b/packages/components/src/collection/src/useScrollableCollection.ts
@@ -1,4 +1,4 @@
-import { CollectionNode } from "@components/";
+import { CollectionNode } from "./useCollection";
 import { RefObject, useLayoutEffect, useState } from "react";
 import { isNil } from "../../shared";
 

--- a/packages/components/src/listbox/src/Listbox.tsx
+++ b/packages/components/src/listbox/src/Listbox.tsx
@@ -356,7 +356,7 @@ export function InnerListbox({
         target: selectionManager.selectedKeys[0] ?? defaultFocusTarget
     });
 
-    const scrollableProps = useScrollableCollection(containerRef, {
+    const scrollableProps = useScrollableCollection(containerRef, nodesProp, {
         // A listbox have a border-size of 1px
         itemSelector: ".o-ui-listbox-option",
         maxHeight: 12 * 32 + 2 * 1,

--- a/packages/components/src/menu/src/Menu.tsx
+++ b/packages/components/src/menu/src/Menu.tsx
@@ -195,7 +195,7 @@ export function InnerMenu({
         target: selectedKeys[0] ?? defaultFocusTarget
     });
 
-    const scrollableProps = useScrollableCollection(containerRef, {
+    const scrollableProps = useScrollableCollection(containerRef, nodesProp, {
         disabled: selectionMode === "none",
         dividerSelector: ".o-ui-menu-divider",
         // A menu have a border-size of 1px


### PR DESCRIPTION
Issue: #752 

## Summary

Autocomplete leaves an empty space or adds a scrollbar depending on the content entered.

## What I did

Adding the number of results returned by the autocomplete (as node) as a dependency of useLayoutEffect for useScrollableCollection makes sure we update the size of the content of the autocomplete Listbox.
