### PR TITLE
Fix Textarea expanding exponentially by revisiting the default line-h…

### DIFF
--- a/packages/components/src/shared/src/index.ts
+++ b/packages/components/src/shared/src/index.ts
@@ -1,7 +1,6 @@
 // Constants
 export * from "./keys";
 export * from "./focusTarget";
-export * from "./values";
 
 // Utils
 export * from "./assertions";
@@ -37,6 +36,7 @@ export * from "./useForceRender";
 export * from "./useResizeObserver";
 export * from "./useRefState";
 export * from "./useFocusWithin";
+export * from "./useFontFaceReady";
 
 // Features
 export * from "./slots";

--- a/packages/components/src/shared/src/index.ts
+++ b/packages/components/src/shared/src/index.ts
@@ -1,6 +1,7 @@
 // Constants
 export * from "./keys";
 export * from "./focusTarget";
+export * from "./values";
 
 // Utils
 export * from "./assertions";

--- a/packages/components/src/shared/src/useFontFaceReady.ts
+++ b/packages/components/src/shared/src/useFontFaceReady.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+const useFontFaceReady = () => {
+    const [ready, setReady] = useState(false);
+
+    useEffect(() => {
+        document.fonts.ready.then(() => {
+            setReady(true);
+        });
+    }, []);
+
+    return ready;
+};
+
+export { useFontFaceReady };

--- a/packages/components/src/shared/src/useFontFaceReady.ts
+++ b/packages/components/src/shared/src/useFontFaceReady.ts
@@ -4,9 +4,14 @@ const useFontFaceReady = () => {
     const [ready, setReady] = useState(false);
 
     useEffect(() => {
-        document.fonts.ready.then(() => {
-            setReady(true);
-        });
+        let isCancelled = false;
+        const loadFonts = async () => {
+            await document.fonts.ready;
+            if (!isCancelled) { setReady(true); }
+        };
+        loadFonts();
+
+        return () => { isCancelled = true; };
     }, []);
 
     return ready;

--- a/packages/components/src/shared/src/values.ts
+++ b/packages/components/src/shared/src/values.ts
@@ -1,3 +1,0 @@
-export enum FontValues {
-    normalLineHeightRatio = 1.28571428571
-}

--- a/packages/components/src/shared/src/values.ts
+++ b/packages/components/src/shared/src/values.ts
@@ -1,0 +1,3 @@
+export enum FontValues {
+    normalLineHeightRatio = 1.28571428571
+}

--- a/packages/components/src/text-area/src/TextArea.css
+++ b/packages/components/src/text-area/src/TextArea.css
@@ -1,6 +1,6 @@
 .o-ui-text-area textarea {
     --o-ui-textarea-padding: var(--o-ui-sp-3);
-    resize: "vertical";
+    resize: vertical;
     /* Fixes a bug where Firefox adds one more row than the one specified. */
     overflow-x: hidden;
     padding: var(--o-ui-sp-2) var(--o-ui-textarea-padding);

--- a/packages/components/src/text-area/src/TextArea.tsx
+++ b/packages/components/src/text-area/src/TextArea.tsx
@@ -1,7 +1,7 @@
 import { AbstractInputProps, useInput, useInputButton, wrappedInputPropsAdapter } from "../../input";
 import { Box, BoxProps } from "../../box";
 import { ChangeEvent, ComponentProps, ReactElement, forwardRef, useCallback, useLayoutEffect, useState } from "react";
-import { OmitInternalProps, cssModule, isNil, mergeProps, useChainedEventCallback, useControllableState } from "../../shared";
+import { FontValues, OmitInternalProps, cssModule, isNil, mergeProps, useChainedEventCallback, useControllableState } from "../../shared";
 import { ResponsiveProp, useResponsiveValue } from "../../styling";
 import { useFieldInputProps } from "../../field";
 
@@ -141,7 +141,7 @@ export function InnerTextArea(props: InnerTextAreaProps) {
         const { fontSize, lineHeight, paddingBottom, paddingTop } = window.getComputedStyle(input);
 
         const padding = pxToInt(paddingTop) + pxToInt(paddingBottom);
-        const currentRows = Math.floor((input.scrollHeight - padding) / pxToInt(lineHeight !== "normal" ? lineHeight : fontSize));
+        const currentRows = Math.floor((input.scrollHeight - padding) / (lineHeight !== "normal" ? pxToInt(lineHeight) : pxToInt(fontSize) * FontValues.normalLineHeightRatio));
 
         const newRows = !isNil(maxRows) && currentRows > maxRows
             ? maxRows

--- a/packages/components/src/text-area/src/TextArea.tsx
+++ b/packages/components/src/text-area/src/TextArea.tsx
@@ -61,8 +61,7 @@ const pxToInt = (value?: string) => {
     return !isNil(value) ? parseInt(value.replace("px", ""), 10) : 0;
 };
 
-function useCalculateLineHeight(inputRef: any) {
-    const input = inputRef.current;
+function useCalculateLineHeight(input: HTMLTextAreaElement) {
     const fontsLoaded = useFontFaceReady();
 
     return useMemo(() => {
@@ -165,7 +164,7 @@ export function InnerTextArea(props: InnerTextAreaProps) {
         value: inputValue
     });
 
-    const lineHeight = useCalculateLineHeight(inputRef);
+    const lineHeight = useCalculateLineHeight(inputRef.current);
 
     const adjustRows = useCallback(() => {
         const input = inputRef.current;

--- a/packages/components/src/text-area/src/TextArea.tsx
+++ b/packages/components/src/text-area/src/TextArea.tsx
@@ -1,7 +1,7 @@
 import { AbstractInputProps, useInput, useInputButton, wrappedInputPropsAdapter } from "../../input";
 import { Box, BoxProps } from "../../box";
-import { ChangeEvent, ComponentProps, ReactElement, forwardRef, useCallback, useLayoutEffect, useState } from "react";
-import { FontValues, OmitInternalProps, cssModule, isNil, mergeProps, useChainedEventCallback, useControllableState } from "../../shared";
+import { ChangeEvent, ComponentProps, ReactElement, forwardRef, useCallback, useLayoutEffect, useMemo, useState } from "react";
+import { OmitInternalProps, cssModule, isNil, mergeProps, useChainedEventCallback, useControllableState, useFontFaceReady } from "../../shared";
 import { ResponsiveProp, useResponsiveValue } from "../../styling";
 import { useFieldInputProps } from "../../field";
 
@@ -60,6 +60,36 @@ export interface InnerTextAreaProps extends AbstractInputProps<typeof DefaultEle
 const pxToInt = (value?: string) => {
     return !isNil(value) ? parseInt(value.replace("px", ""), 10) : 0;
 };
+
+function useCalculateLineHeight(inputRef: any) {
+    const input = inputRef.current;
+    const fontsLoaded = useFontFaceReady();
+
+    return useMemo(() => {
+        if (isNil(input) || !fontsLoaded) {
+            return 0;
+        }
+
+        const { font, lineHeight } = window.getComputedStyle(input);
+
+        if (lineHeight !== "normal") { return pxToInt(lineHeight); }
+
+        const element = document.createElement("SPAN");
+
+        element.id = "o-ui-line-height-helper";
+        element.style.visibility = "hidden";
+        element.style.font = font;
+        element.innerText = "LineHeightHelper";
+
+        document.body.appendChild(element);
+
+        const height = element.getBoundingClientRect().height;
+
+        document.body.removeChild(element);
+
+        return height;
+    }, [input, fontsLoaded]);
+}
 
 export function InnerTextArea(props: InnerTextAreaProps) {
     const [fieldProps] = useFieldInputProps();
@@ -135,20 +165,22 @@ export function InnerTextArea(props: InnerTextAreaProps) {
         value: inputValue
     });
 
+    const lineHeight = useCalculateLineHeight(inputRef);
+
     const adjustRows = useCallback(() => {
         const input = inputRef.current;
 
-        const { fontSize, lineHeight, paddingBottom, paddingTop } = window.getComputedStyle(input);
+        const { paddingBottom, paddingTop } = window.getComputedStyle(input);
 
         const padding = pxToInt(paddingTop) + pxToInt(paddingBottom);
-        const currentRows = Math.floor((input.scrollHeight - padding) / (lineHeight !== "normal" ? pxToInt(lineHeight) : pxToInt(fontSize) * FontValues.normalLineHeightRatio));
+        const currentRows = Math.floor((input.scrollHeight - padding) / lineHeight);
 
         const newRows = !isNil(maxRows) && currentRows > maxRows
             ? maxRows
             : currentRows;
 
         setRows(newRows);
-    }, [inputRef, maxRows]);
+    }, [inputRef, lineHeight, maxRows]);
 
     useLayoutEffect(() => {
         adjustRows();

--- a/packages/components/src/text-area/tests/jest/TextArea.test.tsx
+++ b/packages/components/src/text-area/tests/jest/TextArea.test.tsx
@@ -7,6 +7,10 @@ import userEvent from "@testing-library/user-event";
 
 // ***** Behaviors *****
 
+Object.defineProperty(document, "fonts", {
+    value: { ready: true }
+});
+
 test("when autofocus is true, the input is focused on render", async () => {
     const { getByTestId } = renderWithTheme(
         <TextArea autoFocus aria-label="Label" data-testid="input" />


### PR DESCRIPTION
Issue: 

## Summary

As reported in #755.
The issue happens on the TextArea component. When entering content into the textarea, the number of rows assigned is increasing exponentially as the use types.
This was due to the fact that the maths used to calculate the number of rows was taking a 1:1 ratio for line height set to normal when in reality, depending on the font and the browser that ratio can be 1.2 or even higher.

## What I did

TextArea will add a span at load time, staying hidden, allowing the calculation of the actual height of a line according to the font used.
We needed to introduce the notion of fonts ready to allow for the correct calculation after the fonts were loaded.

## How to test

Tested in storybook on Chrome and Edge. Also tested in Firefox but, while the expand works perfectly, it also adds a small scrollbar on the side of the textarea when adding more rows.

Screen recording: https://share.getcloudapp.com/2NuPqvOD