### PR TITLE
Fix Overlay not overlapping positionned elements

### DIFF
--- a/packages/components/src/overlay/src/Overlay.css
+++ b/packages/components/src/overlay/src/Overlay.css
@@ -7,6 +7,7 @@
     outline: none;
     width: fit-content;
     height: fit-content;
+    position: relative;
 }
 
 /* ARROW */


### PR DESCRIPTION
Issue: 

## Summary

Elements with a position and z-index were displayed over the overlay from Dialogs

## What I did

Adding a position to the Overlay makes sure it goes on top of the other elements