### PR TITLE
Move the focus to the value changing instead of click on the arrows

### DIFF
--- a/packages/components/src/number-input/src/NumberInput.tsx
+++ b/packages/components/src/number-input/src/NumberInput.tsx
@@ -236,6 +236,7 @@ export function InnerNumberInput(props: InnerNumberInputProps) {
 
         if (newInputValue !== inputValueRef.current) {
             setInputValue(newInputValue, true);
+            inputRef.current.focus();
         }
     };
 
@@ -297,10 +298,6 @@ export function InnerNumberInput(props: InnerNumberInputProps) {
 
     const handleDecrement = useEventCallback((event: MouseEvent) => {
         applyStep(event, -1);
-    });
-
-    const handleStepperFocus = useEventCallback(() => {
-        inputRef.current.focus();
     });
 
     const focusWithinProps = useFocusWithin({
@@ -365,7 +362,6 @@ export function InnerNumberInput(props: InnerNumberInputProps) {
                 disableDecrement={readOnly || disabled || (!isNil(numericInputValue) && numericInputValue <= min)}
                 disableIncrement={readOnly || disabled || (!isNil(numericInputValue) && numericInputValue >= max)}
                 onDecrement={handleDecrement}
-                onFocus={handleStepperFocus}
                 onIncrement={handleIncrement}
             />
         </>

--- a/packages/components/src/number-input/src/NumberInput.tsx
+++ b/packages/components/src/number-input/src/NumberInput.tsx
@@ -236,7 +236,6 @@ export function InnerNumberInput(props: InnerNumberInputProps) {
 
         if (newInputValue !== inputValueRef.current) {
             setInputValue(newInputValue, true);
-            inputRef.current.focus();
         }
     };
 
@@ -294,10 +293,12 @@ export function InnerNumberInput(props: InnerNumberInputProps) {
 
     const handleIncrement = useEventCallback((event: MouseEvent) => {
         applyStep(event, 1);
+        inputRef.current.focus();
     });
 
     const handleDecrement = useEventCallback((event: MouseEvent) => {
         applyStep(event, -1);
+        inputRef.current.focus();
     });
 
     const focusWithinProps = useFocusWithin({


### PR DESCRIPTION
Issue: #761 

## Summary

When clicking on the arrows of the NumberInput in Chrome or Edge, the focus is highjacking the active state (as we force it into the input).

## What I did

Moving the focus logic on the event of the value changing fixes the issue, but I'm wondering if it's opening the door to unwanted focus...
