### PR TITLE
Bug: AsyncTabs loader not showing

### DIFF
--- a/packages/components/src/tabs/docs/loader.css
+++ b/packages/components/src/tabs/docs/loader.css
@@ -15,7 +15,7 @@
     top: 50%;
     left: 50%;
     border-radius: 50px;
-    border: 2px solid var(--o-ui-alias-low-break);
+    border: 2px solid var(--o-ui-b-alias-low-break);
     border-top-color: var(--o-ui-white);
     animation: o-ui-button-spinner 1s linear infinite;
     transform: translate(-50%, -50%) rotate(0deg);

--- a/storybook/styles/docs.css
+++ b/storybook/styles/docs.css
@@ -39,7 +39,7 @@
 
 /* ARGS TABLE | HEADER | RESET */
 .docblock-argstable-head button {
-    background-color: var(--o-ui-alias-background-accent) !important;
+    background-color: var(--o-ui-bg-alias-accent) !important;
     box-shadow: none;
 }
 


### PR DESCRIPTION
Issue: 

## Summary

The loader in the Async Tabs example wasn't showing, as reported in #783 

## What I did

Fixed the colour name used from `--o-ui-alias-low-break` to `--o-ui-b-alias-low-break`.