### PR TITLE
remove center alignment in Group. This was added for the ButtonGroup,…

### DIFF
--- a/packages/components/src/group/src/Group.tsx
+++ b/packages/components/src/group/src/Group.tsx
@@ -54,7 +54,7 @@ export function InnerGroup({
     const orientationValue = useResponsiveValue(orientation);
     const wrapValue = useResponsiveValue(wrap);
 
-    const alignProps = useFlexAlignment({ alignX: alignValue, alignY: "center", orientation: orientationValue });
+    const alignProps = useFlexAlignment({ alignX: alignValue, orientation: orientationValue });
 
     return (
         <Flex


### PR DESCRIPTION
remove center alignment in Group. This was added for the ButtonGroup, however we can't find why its necessary. Running chromatic to see what breaks
