### PR TITLE
box shadow artifacts fix - removed theme in doc

### DIFF
--- a/docs/getting-started/styling/PropsReference.stories.mdx
+++ b/docs/getting-started/styling/PropsReference.stories.mdx
@@ -47,7 +47,7 @@ Orbit styled system is organized into categories of style props. Each function p
 ### Color
 
 ```jsx
-<Text backgroundColor="purple-2" color="white">
+<Text backgroundColor="alias-accent-faint" color="alias-static-white">
     Galaxy
 </Text>
 ```

--- a/docs/getting-started/styling/PropsReferenceTable.jsx
+++ b/docs/getting-started/styling/PropsReferenceTable.jsx
@@ -7,7 +7,7 @@ const propTypes = {
 
 const ScaleLinks = {
     "box-shadow-scale": <Link href="?path=/story/shadows--page">1..4 / alias</Link>,
-    "color-scale": <Link href="?path=/story/colors--page">[color]-[1..10] / alias</Link>,
+    "color-scale": <Link href="?path=/story/color-palette--page">[color]-[1..10] / alias</Link>,
     "sizing-scale": <Link href="?path=/story/sizing--page">1..18</Link>,
     "spacing-scale": <Link href="?path=/story/sizing--page">1..13</Link>,
 }

--- a/docs/getting-started/styling/StyledSystem.stories.mdx
+++ b/docs/getting-started/styling/StyledSystem.stories.mdx
@@ -20,9 +20,9 @@ To help achieve a consistent UI, Orbit [style props](#style-props) are based on 
     fontWeight={3}
     padding={3}
     marginBottom={3}
-    color="white"
+    color="alias-static-white"
     borderRadius={3}
-    backgroundColor="accent-5">
+    backgroundColor="alias-accent">
     Lost in space.
 </Div>
 ```
@@ -34,7 +34,7 @@ An Orbit style property is a mapping of a [CSS property](https://developer.mozil
 All style props and style values are discovererable with TypeScript intellisense. Style values intellisense will provide suggestions matching the values provided by the [theme](#theme) as well as the native CSS values of the property. You won't have to guess anymore or open an external documentation to choose a value.
 
 <Preview>
-    <Div width={18} backgroundColor="purple-2" padding={4} borderRadius={2}>
+    <Div width={18} backgroundColor="alias-accent-light" padding={4} borderRadius={2} maxWidth="100%">
         <Paragraph fontSize={4}>Lost in space.</Paragraph>
     </Div>
 </Preview>
@@ -64,7 +64,7 @@ Orbit [style props](#style-props) also supports responsive breakpoints. These br
 By passing an object to any style props, you can specify which style will be applied at different breakpoints. These rules are on a `min-width` basis meaning that a sm value will apply from `768px` and up until another higher breakpoint matches.
 
 <Preview>
-    <Div backgroundColor={{ base: "green-2", xs: "purple-2", sm: "green-2", md: "accent-2", lg: "neutral-2", xl: "warning-2" }} width={18} padding={4}>
+    <Div backgroundColor={{ base: "green-2", xs: "purple-2", sm: "green-2", md: "accent-2", lg: "neutral-2", xl: "warning-2" }} width={18} maxWidth="100%" padding={4}>
         <Paragraph fontSize={4}>Lost in space.</Paragraph>
     </Div>
 </Preview>
@@ -72,7 +72,7 @@ By passing an object to any style props, you can specify which style will be app
 Not all breakpoints needs to be set explicitly. In the following example, `base` and `lg` are explicitly set breakpoints. When match, the `xl` breakpoint will implicitly takes the value set by `lg` breakpoints since it is wider than `lg`. Everything below `lg` inherits the `base` color.
 
 <Preview>
-    <Div backgroundColor={{ base: "green-2", lg: "warning-2" }} width={18} padding={4}>
+    <Div backgroundColor={{ base: "alias-success", lg: "alias-warning" }} width={18} maxWidth="100%" padding={4}>
         <Paragraph fontSize={4}>Lost in space.</Paragraph>
     </Div>
 </Preview>
@@ -97,7 +97,7 @@ The following pseudo states are supported by some styled props and behaves like 
 />
 
 <Preview>
-    <Div backgroundColorHover="green-2" backgroundColor="warning-2" padding={4} width={18}  borderRadius={2}>
+    <Div backgroundColorHover="alias-success-light" backgroundColor="alias-warning-light" padding={4} width={18} maxWidth="100%" borderRadius={2}>
         <Paragraph fontSize={4}>Lost in space.</Paragraph>
     </Div>
 </Preview>
@@ -133,7 +133,7 @@ When applicable, always prefer using a [`<Grid>`](?path=/docs/grid--areas) or [`
 
 Instead of harcoding the foundation values in Orbit like we did in earlier versions, the Orbit styled system is now powered by the values of a theme object provided by the application.
 
-A theme object is a combinaison of design values and design scales. A design scale can be for [typography](?path=/story/typography--page), [spacing](path=/story/spacing--page), [sizing](?path=/story/sizing--page) or even [colors](?path=/story/colors--page). Some scales are defined in Orbit as arrays for ordinal values like `space` or as plain object for named values like `colors`. Some like `fontSizes` are even a mix of both.
+A theme object is a combinaison of design values and design scales. A design scale can be for [typography](?path=/story/typography--page), [spacing](path=/story/spacing--page), [sizing](?path=/story/sizing--page) or even [colors](?path=/story/color-palette--page). Some scales are defined in Orbit as arrays for ordinal values like `space` or as plain object for named values like `colors`. Some like `fontSizes` are even a mix of both.
 
 ### Specification
 

--- a/docs/getting-started/styling/ThemeSpecificationTable.jsx
+++ b/docs/getting-started/styling/ThemeSpecificationTable.jsx
@@ -7,7 +7,7 @@ const propTypes = {
 
 const ScaleLinks = {
     "box-shadow-scale": <Link href="?path=/story/shadows--page">1..4 / alias</Link>,
-    "color-scale": <Link href="?path=/story/colors--page">[color]-[1..10] / alias</Link>,
+    "color-scale": <Link href="?path=/story/color-palette--page">[color]-[1..10] / alias</Link>,
     "sizing-scale": <Link href="?path=/story/sizing--page">1..18</Link>,
     "spacing-scale": <Link href="?path=/story/sizing--page">1..13</Link>,
 }

--- a/docs/materials/Shadows.stories.mdx
+++ b/docs/materials/Shadows.stories.mdx
@@ -19,10 +19,10 @@ import { Div } from "@components/html";
         { title: "Variable", headerStyle: { width: "200px" } },
         { title: "Sample", headerStyle: { width: "350px" } } ]}
     rows={[
-        ["1", "--o-ui-bs-1", <Div boxShadow={1} borderRadius={2} backgroundColor="white" height={9} margin={3}></Div>],
-        ["2", "--o-ui-bs-2", <Div boxShadow={2} borderRadius={2} backgroundColor="white" height={9} margin={3}></Div>],
-        ["3", "--o-ui-bs-3", <Div boxShadow={3} borderRadius={2} backgroundColor="white" height={9} margin={3}></Div>],
-        ["4", "--o-ui-bs-4", <Div boxShadow={4} borderRadius={2} backgroundColor="white" height={9} margin={3}></Div>]
+        ["1", "--o-ui-bs-1", <Div boxShadow={1} borderRadius={2} backgroundColor="alias-static-white" height={9} margin={3}></Div>],
+        ["2", "--o-ui-bs-2", <Div boxShadow={2} borderRadius={2} backgroundColor="alias-static-white" height={9} margin={3}></Div>],
+        ["3", "--o-ui-bs-3", <Div boxShadow={3} borderRadius={2} backgroundColor="alias-static-white" height={9} margin={3}></Div>],
+        ["4", "--o-ui-bs-4", <Div boxShadow={4} borderRadius={2} backgroundColor="alias-static-white" height={9} margin={3}></Div>]
     ]}
     rowClassName="background-1"
 />

--- a/packages/components/src/button/src/Button.css
+++ b/packages/components/src/button/src/Button.css
@@ -38,10 +38,10 @@
 .o-ui-button:after {
     opacity: 0;
     content: "";
-    top: -1px;
-    left: -1px;
-    right: -1px;
-    bottom: -1px;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     display: block;
     position: absolute;
     box-shadow: 0 0 0 var(--o-ui-focus-ring-thickness-md) var(--o-ui-focus-ring-color);
@@ -118,6 +118,13 @@ a.o-ui-button {
 .o-ui-button-secondary {
     border: 1px solid var(--o-ui-b-alias-high-break);
     color: var(--o-ui-text-alias-primary);
+}
+
+.o-ui-button-secondary:after {
+    top: -1px;
+    left: -1px;
+    right: -1px;
+    bottom: -1px;
 }
 
 /* SECONDARY | HOVER */

--- a/packages/components/src/button/src/Button.css
+++ b/packages/components/src/button/src/Button.css
@@ -38,10 +38,10 @@
 .o-ui-button:after {
     opacity: 0;
     content: "";
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    top: -1px;
+    left: -1px;
+    right: -1px;
+    bottom: -1px;
     display: block;
     position: absolute;
     box-shadow: 0 0 0 var(--o-ui-focus-ring-thickness-md) var(--o-ui-focus-ring-color);
@@ -116,7 +116,7 @@ a.o-ui-button {
 
 /* SECONDARY */
 .o-ui-button-secondary {
-    box-shadow: 0 0 0 1px var(--o-ui-b-alias-high-break) inset;
+    border: 1px solid var(--o-ui-b-alias-high-break);
     color: var(--o-ui-text-alias-primary);
 }
 
@@ -283,14 +283,14 @@ a.o-ui-button {
 /* INHERIT | SECONDARY */
 .o-ui-button-inherit-style.o-ui-button-secondary {
     color: inherit;
-    box-shadow: 0 0 0 1px currentColor inset;
+    border: 1px solid currentColor;
 }
 
 .o-ui-button:hover:not(.o-ui-button-loading):not([disabled]).o-ui-button-inherit-style.o-ui-button-secondary,
 .o-ui-button-hover:not(.o-ui-button-loading):not([disabled]).o-ui-button-inherit-style.o-ui-button-secondary {
     background-color: rgba(0, 0, 0, 0.1);
     color: inherit;
-    box-shadow: 0 0 0 1px currentColor inset;
+    border: 1px solid currentColor;
 }
 
 /* INHERIT | SECONDARY | ACTIVE */
@@ -300,7 +300,7 @@ a.o-ui-button {
 .o-ui-button-active:not(.o-ui-button-loading).o-ui-button-inherit-style.o-ui-button-secondary.o-ui-button-basic  {
     background-color: currentColor;
     color: inherit;
-    box-shadow: 0 0 0 1px currentColor inset;
+    border: 1px solid currentColor;
 }
 
 .o-ui-button:active:not(.o-ui-button-loading).o-ui-button-inherit-style.o-ui-button-secondary .o-ui-button-text,

--- a/packages/components/src/checkbox/src/Checkbox.css
+++ b/packages/components/src/checkbox/src/Checkbox.css
@@ -22,7 +22,7 @@
     display: inline-block;
     width: var(--o-ui-sz-3);
     height: var(--o-ui-sz-3);
-    box-shadow: 0 0 0 1px var(--o-ui-b-alias-mid-break) inset;
+    border: 1px solid var(--o-ui-b-alias-mid-break);
     border-radius: var(--o-ui-shape-rounded);
     transition: all var(--o-ui-easing-duration-2) var(--o-ui-easing-productive);
     flex-shrink: 0;
@@ -33,10 +33,10 @@
 .o-ui-checkbox-box:before {
     opacity: 0;
     content: "";
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    top: -1px;
+    left: -1px;
+    right: -1px;
+    bottom: -1px;
     display: block;
     position: absolute;
     box-shadow: 0 0 0 var(--o-ui-focus-ring-thickness-md) var(--o-ui-focus-ring-color);
@@ -124,21 +124,21 @@
 }
 
 .o-ui-checkbox-invalid .o-ui-checkbox-box {
-    box-shadow: 0 0 0 1px var(--o-ui-b-alias-alert) inset;
+    border: 1px solid var(--o-ui-b-alias-alert);
 }
 
 .o-ui-checkbox-checked.o-ui-checkbox-invalid .o-ui-checkbox-box {
     background-color: var(--o-ui-bg-alias-alert);
-    box-shadow: 0 0 0 1px var(--o-ui-b-alias-alert) inset;
+    border: 1px solid var(--o-ui-b-alias-alert);
 }
 
 .o-ui-checkbox.o-ui-checkbox-invalid:hover .o-ui-checkbox-box {
-    box-shadow: 0 0 0 1px var(--o-ui-b-alias-alert) inset;
+    border: 1px solid var(--o-ui-b-alias-alert);
 }
 
 /* STATE | CHECKED */
 .o-ui-checkbox-checked .o-ui-checkbox-box {
-    box-shadow: 0 0 0 1px var(--o-ui-b-alias-accent) inset;
+    border: 1px solid var(--o-ui-bg-alias-accent);
     background-color: var(--o-ui-bg-alias-accent);
 }
 
@@ -163,25 +163,13 @@
 /* STATE | ACTIVE */
 .o-ui-checkbox:not(.o-ui-checkbox-checked) input[type="checkbox"]:active:not([disabled]) + .o-ui-checkbox-box,
 .o-ui-checkbox:not(.o-ui-checkbox-checked).o-ui-checkbox-active input[type="checkbox"]:not([disabled]) + .o-ui-checkbox-box {
-    box-shadow: 0 0 0 1px var(--o-ui-b-alias-high-break) inset;
+    border: 1px solid var(--o-ui-b-alias-high-break);
 }
 
 /* STATE | HOVER */
-.o-ui-checkbox:hover > input[type="checkbox"]:not([disabled]) + .o-ui-checkbox-box,
-.o-ui-checkbox-hover:not(.o-ui-checkbox-disabled) .o-ui-checkbox-box {
-    box-shadow: 0 0 0 1px var(--o-ui-b-alias-high-break) inset;
-}
-
-/* STATE | HOVER | CHECKED */
-.o-ui-checkbox-checked:hover > input[type="checkbox"]:not([disabled]) + .o-ui-checkbox-box,
-.o-ui-checkbox-checked:not(.o-ui-checkbox-disabled).o-ui-checkbox-hover .o-ui-checkbox-box {
-    box-shadow: 0 0 0 1px var(--o-ui-b-alias-accent) inset;
-}
-
-/* STATE | HOVER | CHECKED | BOX */
-.o-ui-checkbox-checked:hover > input[type="checkbox"]:not([disabled]) + .o-ui-checkbox-box:before,
-.o-ui-checkbox-checked:not(.o-ui-checkbox-disabled).o-ui-checkbox-hover .o-ui-checkbox-box:before {
-    box-shadow: 0 0 0 1px var(--o-ui-b-alias-accent) inset;
+.o-ui-checkbox:hover:not(.o-ui-checkbox-checked) > input[type="checkbox"]:not([disabled]) + .o-ui-checkbox-box,
+.o-ui-checkbox-hover:not(.o-ui-checkbox-checked):not(.o-ui-checkbox-disabled) .o-ui-checkbox-box {
+    border: 1px solid var(--o-ui-b-alias-high-break);
 }
 
 /* STATE | HOVER | CHECKED | FOCUS | BOX */
@@ -189,7 +177,7 @@
 .o-ui-checkbox-checked.o-ui-checkbox-hover input[type="checkbox"]:not([disabled]):focus-visible + .o-ui-checkbox-box:before,
 .o-ui-checkbox-checked:not(.o-ui-checkbox-disabled).o-ui-checkbox-focus:hover .o-ui-checkbox-box:before,
 .o-ui-checkbox-checked:not(.o-ui-checkbox-disabled).o-ui-checkbox-focus.o-ui-checkbox-hover .o-ui-checkbox-box:before {
-    box-shadow: 0 0 0 var(--o-ui-focus-ring-thickness-md) var(--o-ui-focus-ring-color);
+    border: var(--o-ui-focus-ring-thickness-md) solid var(--o-ui-focus-ring-color);
 }
 
 /* SIZING */

--- a/packages/components/src/checkbox/src/Checkbox.tsx
+++ b/packages/components/src/checkbox/src/Checkbox.tsx
@@ -3,6 +3,7 @@ import { Box } from "../../box";
 import { ChangeEvent, ChangeEventHandler, ComponentProps, forwardRef, useMemo } from "react";
 import { OmitInternalProps, isNil, mergeProps, omitProps, resolveChildren, useChainedEventCallback, useCheckableProps, useSlots } from "../../shared";
 import { ResponsiveProp, useResponsiveValue } from "../../styling";
+import { Span } from "../../html";
 import { Text } from "../../typography";
 import { VisuallyHidden } from "../../visually-hidden";
 import { embeddedIconSize } from "../../icons";
@@ -181,7 +182,7 @@ export function InnerCheckbox(props: InnerCheckboxProps) {
             )}
         >
             <VisuallyHidden {...inputProps} />
-            <span className="o-ui-checkbox-box" />
+            <Span className="o-ui-checkbox-box" />
             {text}
             {icon}
             {counter}

--- a/packages/components/src/input-group/src/InputGroup.css
+++ b/packages/components/src/input-group/src/InputGroup.css
@@ -89,7 +89,7 @@
 
 /* BUTTON ADDON */
 .o-ui-input-group .o-ui-input-group-button-addon {
-    box-shadow: 0 0 0 1px var(--o-ui-input-border-color) inset;
+    border: 1px solid var(--o-ui-input-border-color);
 }
 
 /* SELECT ADDON */

--- a/packages/components/src/layout/docs/Grid.stories.mdx
+++ b/packages/components/src/layout/docs/Grid.stories.mdx
@@ -180,11 +180,11 @@ A custom `minmax` function is available to support Orbit spacing scalue values. 
             templateColumns={[fitContent(9), fitContent(9), "1fr"]}
             gap={2}
             alignItems="center"
-            color="white"
+            color="alias-static-white"
         >
-            <Div backgroundColor="accent-5" padding={1}>Mars</Div>
-            <Div backgroundColor="alert-5" padding={1}>Pluto</Div>
-            <Div backgroundColor="green-5" padding={1}>Jupiter</Div>
+            <Div backgroundColor="alias-accent" padding={1}>Mars</Div>
+            <Div backgroundColor="alias-alert" padding={1}>Pluto</Div>
+            <Div backgroundColor="alias-success" padding={1}>Jupiter</Div>
         </Grid>
     </Story>
 </Preview>

--- a/packages/components/src/styling/tests/chromatic/useStyledSystem.chroma.jsx
+++ b/packages/components/src/styling/tests/chromatic/useStyledSystem.chroma.jsx
@@ -14,7 +14,7 @@ stories()
     .add("every single breakpoints", () =>
         <Box
             backgroundColor={{ base: "purple-5", xs: "green-5", sm: "alert-5", md: "purple-5", lg: "neutral-5", xl: "green-5" }}
-            color="static-white"
+            color="alias-static-white"
             width={12}
         >
                 Space X
@@ -28,7 +28,7 @@ stories()
     .add("match higher breakpoint", () =>
         <Box
             backgroundColor={{ base: "purple-3", sm: "alert-3" }}
-            color="static-white"
+            color="alias-static-white"
             width={12}
         >
             Space X
@@ -42,7 +42,7 @@ stories()
     .add("match base", () =>
         <Box
             backgroundColor={{ base: "purple-8" }}
-            color="static-white"
+            color="alias-static-white"
             width={12}
         >
             Space X

--- a/packages/components/src/styling/tests/chromatic/useStyledSystem.chroma.jsx
+++ b/packages/components/src/styling/tests/chromatic/useStyledSystem.chroma.jsx
@@ -14,7 +14,7 @@ stories()
     .add("every single breakpoints", () =>
         <Box
             backgroundColor={{ base: "purple-5", xs: "green-5", sm: "alert-5", md: "purple-5", lg: "neutral-5", xl: "green-5" }}
-            color="white"
+            color="static-white"
             width={12}
         >
                 Space X
@@ -28,7 +28,7 @@ stories()
     .add("match higher breakpoint", () =>
         <Box
             backgroundColor={{ base: "purple-3", sm: "alert-3" }}
-            color="white"
+            color="static-white"
             width={12}
         >
             Space X
@@ -42,7 +42,7 @@ stories()
     .add("match base", () =>
         <Box
             backgroundColor={{ base: "purple-8" }}
-            color="white"
+            color="static-white"
             width={12}
         >
             Space X

--- a/packages/components/src/tag/src/Tag.css
+++ b/packages/components/src/tag/src/Tag.css
@@ -24,10 +24,10 @@ button.o-ui-tag:after,
 a.o-ui-tag:after {
     opacity: 0;
     content: "";
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    top: -1px;
+    left: -1px;
+    right: -1px;
+    bottom: -1px;
     display: block;
     position: absolute;
     box-shadow: 0 0 0 var(--o-ui-focus-ring-thickness-md) var(--o-ui-focus-ring-color);
@@ -36,6 +36,13 @@ a.o-ui-tag:after {
 }
 
 /* AS ANCHOR / BUTTON | STATE | FOCUS */
+button:not([disabled]).o-ui-tag:focus-visible,
+a:not([disabled]).o-ui-tag:focus-visible,
+button:not([disabled]).o-ui-tag.o-ui-tag-focus,
+a:not([disabled]).o-ui-tag.o-ui-tag-focus {
+    outline: none;
+}
+
 button:not([disabled]).o-ui-tag:focus-visible:after,
 a:not([disabled]).o-ui-tag:focus-visible:after,
 button:not([disabled]).o-ui-tag.o-ui-tag-focus:after,
@@ -113,7 +120,7 @@ a.o-ui-tag-solid.o-ui-tag-disabled {
 /* OUTLINE */
 .o-ui-tag-outline {
     background-color: var(--o-ui-bg-alias-default);
-    box-shadow: 0 0 0 1px var(--o-ui-b-alias-low-break) inset;
+    border: 1px solid var(--o-ui-b-alias-low-break);
 }
 
 /* OUTLINE | AS ANCHOR / BUTTON | STATES */
@@ -123,7 +130,7 @@ a:not([disabled]).o-ui-tag-outline:hover,
 button:not([disabled]).o-ui-tag-outline.o-ui-tag-hover,
 a:not([disabled]).o-ui-tag-outline.o-ui-tag-hover {
     background-color: var(--o-ui-bg-alias-basic-transparent-hover);
-    box-shadow: 0 0 0 1px var(--o-ui-b-alias-mid-break) inset;
+    border: 1px solid var(--o-ui-b-alias-mid-break);
 }
 
 /* OUTLINE | AS ANCHOR / BUTTON | STATES | ACTIVE */
@@ -132,7 +139,7 @@ a:not([disabled]).o-ui-tag-outline:active,
 button:not([disabled]).o-ui-tag-outline.o-ui-tag-active,
 a:not([disabled]).o-ui-tag-outline.o-ui-tag-active {
     background-color: var(--o-ui-bg-alias-basic-transparent-active);
-    box-shadow: 0 0 0 1px var(--o-ui-b-alias-high-break) inset;
+    border: 1px solid var(--o-ui-b-alias-high-break);
 }
 
 /* OUTLINE | AS ANCHOR / BUTTON | STATES | DISABLED */

--- a/packages/components/src/tag/src/Tag.css
+++ b/packages/components/src/tag/src/Tag.css
@@ -24,10 +24,10 @@ button.o-ui-tag:after,
 a.o-ui-tag:after {
     opacity: 0;
     content: "";
-    top: -1px;
-    left: -1px;
-    right: -1px;
-    bottom: -1px;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     display: block;
     position: absolute;
     box-shadow: 0 0 0 var(--o-ui-focus-ring-thickness-md) var(--o-ui-focus-ring-color);
@@ -121,6 +121,14 @@ a.o-ui-tag-solid.o-ui-tag-disabled {
 .o-ui-tag-outline {
     background-color: var(--o-ui-bg-alias-default);
     border: 1px solid var(--o-ui-b-alias-low-break);
+}
+
+button.o-ui-tag-outline::after,
+a.o-ui-tag-outline::after {
+    top: -1px;
+    left: -1px;
+    right: -1px;
+    bottom: -1px;
 }
 
 /* OUTLINE | AS ANCHOR / BUTTON | STATES */

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -108,15 +108,6 @@ if (isDocs) {
 }
 
 export const globalTypes = {
-    theme: {
-        name: "Theme",
-        description: "Theme for components",
-        defaultValue: ShareGateTheme.name,
-        toolbar: {
-            icon: "photo",
-            items: [ShareGateTheme.name]
-        }
-    },
     colorScheme: {
         name: "ColorScheme",
         description: "Color scheme for components",


### PR DESCRIPTION
Issue: 

## Summary

#791 / #792 

## What I did

Every components using box-shadow for a fake border reverted back to using a border instead.

Remove the ThemeSwitcher in the Doc. If we ever have two themes it'll be easy to have it back.

## How to test

- #791 : /?path=/docs/button--default-story#icon /?path=/docs/tag--default-story /?path=/docs/checkbox--default-story
- #792 : Check in the doc top bar that the theme picker is gone