### PR TITLE
Bug/801 modals trap focus

### DIFF
--- a/packages/components/src/card/src/Card.css
+++ b/packages/components/src/card/src/Card.css
@@ -3,6 +3,7 @@
     background-color: var(--o-ui-bg-alias-default);
     border-radius: var(--o-ui-shape-rounded);
     border: 1px solid var(--o-ui-b-alias-low-break);
+    height: max-content;
 }
 
 /* SIZES */

--- a/packages/components/src/shared/src/focusableTreeWalker.ts
+++ b/packages/components/src/shared/src/focusableTreeWalker.ts
@@ -1,6 +1,6 @@
 // Tree walker code have been copied from: https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/focus/src/FocusScope.tsx.
 
-const FocusableElement = [
+const FocusableElements = [
     "input:not([disabled]):not([type=hidden])",
     "select:not([disabled])",
     "textarea:not([disabled])",
@@ -16,12 +16,60 @@ const FocusableElement = [
     "[contenteditable]"
 ];
 
-export const FocusableElementSelector = [...FocusableElement, "[tabindex]"].join(",");
+export const FocusableElementSelector = FocusableElements.join(":not([hidden]),") + ",[tabindex]:not([disabled]):not([hidden])";
+FocusableElements.push("[tabindex]:not([tabindex=\"-1\"]):not([disabled])");
 
-export const TabbableElementSelector = [...FocusableElement, "[tabindex]:not([tabindex=\"-1\"])"].join(":not([tabindex=\"-1\"]),");
+export const TabbableElementSelector = FocusableElements.join(":not([hidden]):not([tabindex=\"-1\"]),");
 
 export interface FocusableTreeWalkerOptions {
     tabbable?: boolean;
+}
+
+function isStyleVisible(element: Element) {
+    if (!(element instanceof HTMLElement) && !(element instanceof SVGElement)) {
+        return false;
+    }
+
+    const { display, visibility } = element.style;
+
+    let isVisible = (
+        display !== "none" &&
+        visibility !== "hidden" &&
+        visibility !== "collapse"
+    );
+
+    if (isVisible) {
+        const { getComputedStyle } = element.ownerDocument.defaultView;
+        const { display: computedDisplay, visibility: computedVisibility } = getComputedStyle(element);
+
+        isVisible = (
+            computedDisplay !== "none" &&
+            computedVisibility !== "hidden" &&
+            computedVisibility !== "collapse"
+        );
+    }
+
+    return isVisible;
+}
+
+function isAttributeVisible(element: Element, childElement?: Element) {
+    return (
+        !element.hasAttribute("hidden") &&
+        (element.nodeName === "DETAILS" &&
+            childElement &&
+            childElement.nodeName !== "SUMMARY"
+            ? element.hasAttribute("open")
+            : true)
+    );
+}
+
+function isElementVisible(element: Element, childElement?: Element) {
+    return (
+        element.nodeName !== "#comment" &&
+        isStyleVisible(element) &&
+        isAttributeVisible(element, childElement) &&
+        (!element.parentElement || isElementVisible(element.parentElement, element))
+    );
 }
 
 export function createFocusableTreeWalker(root: HTMLElement, { tabbable }: FocusableTreeWalkerOptions = {}): TreeWalker {
@@ -32,7 +80,7 @@ export function createFocusableTreeWalker(root: HTMLElement, { tabbable }: Focus
         NodeFilter.SHOW_ELEMENT,
         {
             acceptNode(node) {
-                if ((node as HTMLElement).matches(selector)) {
+                if ((node as HTMLElement).matches(selector) && isElementVisible(node as HTMLElement)) {
                     return NodeFilter.FILTER_ACCEPT;
                 }
 

--- a/packages/components/src/shared/src/useFocusManager.ts
+++ b/packages/components/src/shared/src/useFocusManager.ts
@@ -100,6 +100,10 @@ export class FocusManager {
         return element;
     }
 
+    getVisibileElements(elements: HTMLElement[]) {
+        return elements.filter(x => (x.offsetWidth > 0 && x.offsetHeight > 0));
+    }
+
     focusFirst({ canFocus, ...options }: FocusOptions = {}) {
         const { elements } = this.scope;
 
@@ -141,18 +145,20 @@ export class FocusManager {
     focusNext({ canFocus, ...options }: FocusOptions = {}) {
         const { elements } = this.scope;
 
+        const visibleElements = this.getVisibileElements(elements);
+
         let target;
 
-        if (elements.length > 0) {
+        if (visibleElements.length > 0) {
             let hasLooped = false;
 
             canFocus = !isNil(canFocus) ? canFocus : () => true;
 
             const index = this.isVirtual
-                ? elements.findIndex(x => x.classList.contains(VirtualFocusCssClass))
-                : elements.indexOf(document.activeElement as HTMLElement);
+                ? visibleElements.findIndex(x => x.classList.contains(VirtualFocusCssClass))
+                : visibleElements.indexOf(document.activeElement as HTMLElement);
 
-            const iterator = new ElementIterator(elements, { from: index !== -1 ? index : undefined });
+            const iterator = new ElementIterator(visibleElements, { from: index !== -1 ? index : undefined });
 
             do {
                 target = iterator.next();
@@ -179,24 +185,26 @@ export class FocusManager {
     focusPrevious({ canFocus, ...options }: FocusOptions = {}) {
         const { elements } = this.scope;
 
+        const visibleElements = this.getVisibileElements(elements);
+
         let target;
 
-        if (elements.length > 0) {
+        if (visibleElements.length > 0) {
             let hasLooped = false;
 
             canFocus = !isNil(canFocus) ? canFocus : () => true;
 
             const index = this.isVirtual
-                ? elements.findIndex(x => x.classList.contains(VirtualFocusCssClass))
-                : elements.indexOf(document.activeElement as HTMLElement);
+                ? visibleElements.findIndex(x => x.classList.contains(VirtualFocusCssClass))
+                : visibleElements.indexOf(document.activeElement as HTMLElement);
 
-            const iterator = new ElementIterator(elements, { from: index !== -1 ? index : undefined });
+            const iterator = new ElementIterator(visibleElements, { from: index !== -1 ? index : undefined });
 
             do {
                 target = iterator.previous();
 
                 if (isNil(target)) {
-                    iterator.reset({ from: elements.length });
+                    iterator.reset({ from: visibleElements.length });
                 }
 
                 // If we do a full loop it means there are no focusable elements (probably because of canFocus)

--- a/packages/components/src/shared/src/useFocusScope.ts
+++ b/packages/components/src/shared/src/useFocusScope.ts
@@ -17,6 +17,12 @@ export class DomScope {
         return this.scopeRef.current;
     }
 
+    getScopeRoot() {
+        if (!this.elements || this.elements.length === 0) { return null; }
+
+        return this.elements[0].parentElement;
+    }
+
     registerChangeHandler(handler: ScopeChangeEventHandler) {
         this.handlersRef.current.push(handler);
     }


### PR DESCRIPTION
Issue: #801 

## Summary

The Focus Trap gets locked on any element placed before a hidden focusable element (like a radio button inside of a Disclosure)

## What I did

Adding a check on the elements Trap Focus is going through to make sure they are visible at the time the user tabs through the focusable elements.

Recording: https://share.getcloudapp.com/llukpR2J
