### PR TITLE
RadioGroup onChange handler is now called when switching the value with keyboard arrows

### DIFF
--- a/packages/components/src/icons/src/Icon.tsx
+++ b/packages/components/src/icons/src/Icon.tsx
@@ -1,7 +1,8 @@
-import { Box } from "../../box";
 import { ComponentProps, ElementType, SVGProps, forwardRef } from "react";
 import { InternalProps, OmitInternalProps, SlotProps, cssModule, isNil, mergeProps, normalizeSize, slot } from "../../shared";
 import { ResponsiveProp, StyledSystemProps, useResponsiveValue, useStyleProps } from "../../styling";
+
+import { Box } from "../../box";
 
 export type IconSize = "2xs" | "xs" | "sm" | "md" | "lg" | "xl" | "inherit";
 

--- a/packages/components/src/radio/src/Radio.tsx
+++ b/packages/components/src/radio/src/Radio.tsx
@@ -1,5 +1,3 @@
-import { AbstractInputProps } from "../../input";
-import { Box } from "../../box";
 import { ChangeEvent, ChangeEventHandler, ComponentProps, ReactNode, forwardRef, useImperativeHandle, useMemo, useRef } from "react";
 import {
     OmitInternalProps,
@@ -16,6 +14,9 @@ import {
     useForwardInputApi,
     useSlots
 } from "../../shared";
+
+import { AbstractInputProps } from "../../input";
+import { Box } from "../../box";
 import { Span } from "../../html";
 import { Text } from "../../typography";
 import { VisuallyHidden } from "../../visually-hidden";

--- a/packages/components/src/radio/src/RadioGroup.tsx
+++ b/packages/components/src/radio/src/RadioGroup.tsx
@@ -18,7 +18,8 @@ import {
     useKeyedRovingFocus,
     useMergedRefs
 } from "../../shared";
-import { Children, ComponentProps, ReactElement, SyntheticEvent, forwardRef } from "react";
+import { Children, ComponentProps, ReactElement, SyntheticEvent, forwardRef, useCallback } from "react";
+
 import { Group } from "../../group";
 import { useFieldInputProps } from "../../field";
 import { useResponsiveValue } from "../../styling";
@@ -83,13 +84,21 @@ export function InnerRadioGroup(props: InnerRadioGroupProps) {
 
     const groupRef = useMergedRefs(setFocusRef, forwardedRef);
 
+    const setNewValue = useCallback((event, newValue) => {
+        if (!isNil(onChange)) {
+            onChange(event, newValue);
+        }
+
+        setCheckedValue(newValue);
+    }, [setCheckedValue, onChange]);
+
     const handleArrowSelect = useEventCallback((event, element) => {
         // When a number value is provided it's converted to a string when a new value is selected using the keyboard arrows.
         const newValue = element.dataset.type === "number"
             ? parseInt(element.value)
             : element.value;
 
-        setCheckedValue(newValue);
+        setNewValue(event, newValue);
     });
 
     const focusManager = useFocusManager(focusScope, { keyProp: RadioKeyProp });
@@ -120,11 +129,7 @@ export function InnerRadioGroup(props: InnerRadioGroupProps) {
     });
 
     const handleCheck = useEventCallback((event: SyntheticEvent, newValue: string) => {
-        if (!isNil(onChange)) {
-            onChange(event, newValue);
-        }
-
-        setCheckedValue(newValue);
+        setNewValue(event, newValue);
     });
 
     const groupName = useId(name, "radio-group");

--- a/packages/components/src/radio/tests/chromatic/Radio.chroma.jsx
+++ b/packages/components/src/radio/tests/chromatic/Radio.chroma.jsx
@@ -1,7 +1,8 @@
+import { paramsBuilder, storiesOfBuilder } from "@stories/utils";
+
 import { Inline } from "@components/layout";
 import { Radio } from "@components/radio";
 import { createRadioTestSuite } from "./createRadioTestSuite";
-import { paramsBuilder, storiesOfBuilder } from "@stories/utils";
 
 function stories(segment) {
     return storiesOfBuilder(module, "Chromatic/Radio")

--- a/packages/components/src/radio/tests/chromatic/RadioGroup.chroma.jsx
+++ b/packages/components/src/radio/tests/chromatic/RadioGroup.chroma.jsx
@@ -1,12 +1,13 @@
-import { Counter } from "@components/counter";
-import { Div } from "@components/html";
 import { Field, HelpMessage, Label } from "@components/field";
 import { Inline, Stack } from "@components/layout";
 import { Radio, RadioGroup } from "@components/radio";
+import { paramsBuilder, storiesOfBuilder } from "@stories/utils";
+
+import { Counter } from "@components/counter";
+import { Div } from "@components/html";
 import { Tag } from "@components/tag";
 import { Text } from "@components/typography";
 import { ToggleButton } from "@components/button";
-import { paramsBuilder, storiesOfBuilder } from "@stories/utils";
 import { useCallback } from "react";
 import { useCheckableProps } from "@components/shared";
 
@@ -47,7 +48,7 @@ function CustomComponent({
 
 stories()
     .add("default", () =>
-        <RadioGroup>
+        <RadioGroup onChange={() => { console.log("Changed!"); }}>
             <Radio value="1">1</Radio>
             <Radio value="2">2</Radio>
             <Radio value="3">3</Radio>

--- a/packages/components/src/radio/tests/chromatic/RadioGroup.chroma.jsx
+++ b/packages/components/src/radio/tests/chromatic/RadioGroup.chroma.jsx
@@ -48,7 +48,7 @@ function CustomComponent({
 
 stories()
     .add("default", () =>
-        <RadioGroup onChange={() => { console.log("Changed!"); }}>
+        <RadioGroup>
             <Radio value="1">1</Radio>
             <Radio value="2">2</Radio>
             <Radio value="3">3</Radio>

--- a/packages/components/src/radio/tests/jest/RadioGroup.test.tsx
+++ b/packages/components/src/radio/tests/jest/RadioGroup.test.tsx
@@ -233,6 +233,31 @@ test("call onChange when a radio is selected", async () => {
     await waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
 });
 
+test("call onChange when a radio is selected with the keyboard arrows", async () => {
+    const handler = jest.fn();
+
+    const { getByTestId } = renderWithTheme(
+        <RadioGroup
+            onChange={handler}
+        >
+            <Radio value="1" data-testid="radio-1">1</Radio>
+            <Radio value="2">2</Radio>
+            <Radio value="3">3</Radio>
+        </RadioGroup>
+    );
+
+    act(() => {
+        getInput(getByTestId("radio-1")).focus();
+    });
+
+    act(() => {
+        fireEvent.keyDown(getInput(getByTestId("radio-1")), { key: Keys.arrowRight });
+    });
+
+    await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), "2"));
+    await waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
+});
+
 test("call the radio onValueChange handler when a radio is selected", async () => {
     const handler = jest.fn();
 


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Issue:  https://github.com/gsoft-inc/sg-orbit/issues/826

## Summary

RadioGroup onChange handler is now called when switching the value with keyboard arrows

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes

- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.
