### PR TITLE
Fix theme provider docs and added a useColorValue hook

### DIFF
--- a/docs/getting-started/Slots.stories.mdx
+++ b/docs/getting-started/Slots.stories.mdx
@@ -44,11 +44,11 @@ To use an implicit slot, declare a component having a default slot as a children
 
 You can define an implicit slot on a custom component by using the `slot` function.
 
-```js
+```jsx
 import { slot } from "@sharegate/orbit-ui";
 
 export const MyComponent = slot("name-of-the-slot-to-fulfill-by-default", () => (
-    <Box>A custom component</Box>
+    <Div>A custom component</Div>
 ));
 ```
 
@@ -63,13 +63,13 @@ An explicit slot is defined by specifying the `slot` prop on a component declara
 </Button>
 ```
 
-For native HTML elements, instead of specifying an explicit slot directly on the native element, we do recommend you use the [`<Box>`](?path=/docs/box--default-story) component to prevent rendering a `slot` attribute on the element.
+For native HTML elements, instead of specifying an explicit slot directly on the native element, we do recommend you use [Orbit HTML elements](?path=/docs/html-anchor--example).
 
 ```jsx
 <Card>
     <H1>SpaceX delays launch of South Korean military satellite</H1>
-    <Box slot="content">SpaceX postponed the upcoming launch of a South Korean military satellite Monday (July 13), due to hardware issues with the Falcon 9 rocket.</Box>
-    <Box slot="footer">Copyright @2021</Box>
+    <Div slot="content">SpaceX postponed the upcoming launch of a South Korean military satellite Monday (July 13), due to hardware issues with the Falcon 9 rocket.</Div>
+    <Div slot="footer">Copyright @2021</Div>
 </Card>
 ```
 

--- a/jest/utils/renderWithTheme.tsx
+++ b/jest/utils/renderWithTheme.tsx
@@ -1,12 +1,18 @@
-import { ThemeProvider, ShareGateTheme } from "@components/styling";
-import { ReactNode, ReactElement } from "react";
+import { ColorScheme, ShareGateTheme, ThemeProvider } from "@components/styling";
+import { ReactElement, ReactNode } from "react";
+import { RenderHookOptions, renderHook } from "@testing-library/react-hooks";
+
 import { render } from "@testing-library/react";
 
-function withThemeProvider() {
+export interface JestThemeOptions {
+    colorScheme?: ColorScheme
+}
+
+function withThemeProvider({ colorScheme = "light" }: JestThemeOptions = {}) {
     return {
         wrapper: ({ children }: { children?: ReactNode }) => {
             return (
-                <ThemeProvider theme={ShareGateTheme} colorScheme="light">
+                <ThemeProvider theme={ShareGateTheme} colorScheme={colorScheme}>
                     {children}
                 </ThemeProvider>
             )
@@ -14,9 +20,16 @@ function withThemeProvider() {
     };
 }
 
-export function renderWithTheme(ui: ReactElement, options?: Record<any, any>) {
+export function renderWithTheme(ui: ReactElement, testingLibraryOptions?: Record<any, any>, themeOptions?: JestThemeOptions) {
     return render(ui, {
-        ...withThemeProvider(),
-        ...options
+        ...withThemeProvider(themeOptions),
+        ...testingLibraryOptions
+    })
+}
+
+export function renderHookWithTheme<TProps, TResult>(callback: (props: TProps) => TResult, renderHookOptions?: RenderHookOptions<TProps>, themeOptions?: JestThemeOptions) {
+    return renderHook(callback, {
+        ...withThemeProvider(themeOptions),
+        ...renderHookOptions
     })
 }

--- a/packages/components/src/radio/tests/chromatic/RadioGroup.chroma.jsx
+++ b/packages/components/src/radio/tests/chromatic/RadioGroup.chroma.jsx
@@ -38,8 +38,8 @@ function CustomComponent({
             as="button"
             value={value}
             onClick={handleCheck}
-            color={isChecked?"white": undefined}
-            backgroundColor={isChecked?"accent-6": "neutral-6"}
+            color={isChecked ? "white" : undefined}
+            backgroundColor={isChecked ? "accent-6" : "neutral-6"}
         >
             {children}
         </Tag>

--- a/packages/components/src/styling/docs/theme-provider/ColorSchemePicker.sample.jsx
+++ b/packages/components/src/styling/docs/theme-provider/ColorSchemePicker.sample.jsx
@@ -2,10 +2,7 @@ function ColorSchemePicker() {
     const { colorScheme, setColorScheme } = useThemeContext();
 
     return (
-        <Inline
-            gap={1}
-            backgroundColor="alias-default"
-        >
+        <Inline gap={1}>
             <Text marginRight={2}>Color Scheme: </Text>
             <TextLink
                 onClick={() => setColorScheme("light")}
@@ -27,8 +24,8 @@ function ColorSchemePicker() {
 render(() => {
     return (
         <ThemeProvider theme={ShareGateTheme} colorScheme="system" defaultColorScheme="light">
-            <Stack>
-                <Button variant="primary">Cutoff</Button>
+            <Stack backgroundColor="alias-default">
+                <Button variant="secondary">Cutoff</Button>
                 <ColorSchemePicker />
             </Stack>
         </ThemeProvider>

--- a/packages/components/src/styling/docs/theme-provider/CustomColorHook.sample.jsx
+++ b/packages/components/src/styling/docs/theme-provider/CustomColorHook.sample.jsx
@@ -1,0 +1,13 @@
+() => {
+    const color = useColorValue("#fff", "#000");
+    const backgroundColor = useColorValue("#ff9048", "#fee2bb");
+
+    return (
+        <Button
+            color={color}
+            backgroundColor={backgroundColor}
+        >
+            Cutoff
+        </Button>
+    );
+};

--- a/packages/components/src/styling/docs/theme-provider/ThemeProvider.stories.mdx
+++ b/packages/components/src/styling/docs/theme-provider/ThemeProvider.stories.mdx
@@ -34,7 +34,7 @@ A default theme provider.
 <Preview scope={{ ShareGateTheme }}>
     <Story name="default">
         <ThemeProvider theme={ShareGateTheme} colorScheme="light">
-            <Button variant="primary">Cutoff</Button>
+            <Button variant="secondary">Cutoff</Button>
         </ThemeProvider>
     </Story>
 </Preview>
@@ -48,7 +48,7 @@ To enable this feature, you must pass the `system` value to `colorScheme` and an
 <Preview>
     <Story name="system">
         <ThemeProvider theme={ShareGateTheme} colorScheme="system" defaultColorScheme="light">
-            <Button variant="primary">Cutoff</Button>
+            <Button variant="secondary">Cutoff</Button>
         </ThemeProvider>
     </Story>
 </Preview>
@@ -58,6 +58,12 @@ To enable this feature, you must pass the `system` value to `colorScheme` and an
 The closest `ThemeContext` can be accessed with the `useThemeContext` hook. Once you have an hold on the context, you can access is values and update the `colorScheme`.
 
 <Preview filePath="/styling/docs/theme-provider/ColorSchemePicker" />
+
+### Custom color
+
+Some features requires the usage of custom colors. Those colors aren't like Orbit's aliases and will not support multiple color schemes (dark mode) out of the box. To help with that, Orbit offer the `useColorValue` hook.
+
+<Preview filePath="/styling/docs/theme-provider/CustomColorHook" />
 
 ## API
 

--- a/packages/components/src/styling/src/index.ts
+++ b/packages/components/src/styling/src/index.ts
@@ -2,7 +2,9 @@ export * from "./BreakpointProvider";
 export * from "./styled-system";
 export * from "./StyleContext";
 export * from "./theming";
+export * from "./useColorValue";
 export * from "./useColorScheme";
+export * from "./useColorValue";
 export * from "./useMediaQuery";
 export * from "./useResponsiveValue";
 

--- a/packages/components/src/styling/src/theming/orbitTheme.ts
+++ b/packages/components/src/styling/src/theming/orbitTheme.ts
@@ -1,6 +1,6 @@
 import { ConditionalKeys, FixedLengthArray } from "type-fest";
-import { Property } from "csstype";
-import type { ColorExpressionTypes } from "../styled-system";
+
+import { CssColor } from "../styled-system";
 
 export interface ColorSchemeSection<C, L, D> {
     common?: Partial<C>;
@@ -62,8 +62,7 @@ export interface ColorPaletteSection {
 type AliasValue =
     `$${ConditionalKeys<ColorPaletteSection, ColorPalette>}-${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10}` | // any color in palette $accent-5
     `$${ConditionalKeys<ColorPaletteSection, string>}` | // any static colors $white $black
-    `${typeof ColorExpressionTypes[number]}${string}` | // strings starting with hsl(a), rgb(a), #
-    Property.Color; // basic colors
+    CssColor; // hsl(a), rgb(a), #, etc...
 
 export interface ColorAliases {
     /* Background */

--- a/packages/components/src/styling/src/useColorValue.ts
+++ b/packages/components/src/styling/src/useColorValue.ts
@@ -1,0 +1,7 @@
+import { useThemeContext } from "./theming";
+
+export function useColorValue(lightColor: string, darkColor: string) {
+    const { colorScheme } = useThemeContext();
+
+    return colorScheme === "dark" ? darkColor : lightColor;
+}

--- a/packages/components/src/styling/tests/jest/useColorValue.test.ts
+++ b/packages/components/src/styling/tests/jest/useColorValue.test.ts
@@ -1,0 +1,14 @@
+import { renderHookWithTheme } from "@jest-utils";
+import { useColorValue } from "@components/styling";
+
+test("return the light color value when the color scheme is light", async () => {
+    const { result } = renderHookWithTheme(() => useColorValue("light-color", "dark-color"), undefined, { colorScheme: "light" });
+
+    expect(result.current).toBe("light-color");
+});
+
+test("return the dark color value when the color scheme is dark", async () => {
+    const { result } = renderHookWithTheme(() => useColorValue("light-color", "dark-color"), undefined, { colorScheme: "dark" });
+
+    expect(result.current).toBe("dark-color");
+});


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Issue: https://github.com/gsoft-inc/sg-orbit/issues/807

## Summary

- Fix ThemeProvider docs. All examples were using a primary variant. A primary button use the same colors for light & dark which were preventing from showing any theme feature.
- Added a `useColorValue` hook to allow a dev to easily use a custom color with color scheme support.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes

- Does this need an update to the documentation? Yes

If your answer is yes to any of these, please make sure to include it in your PR.
