### PR TITLE
Fix popover closing when clicking on the trigger

### DIFF
--- a/packages/components/src/dialog/src/Dialog.tsx
+++ b/packages/components/src/dialog/src/Dialog.tsx
@@ -23,7 +23,7 @@ import {
     useSlots
 } from "../../shared";
 import { ResponsiveProp, useResponsiveValue } from "../../styling";
-import { Underlay, useOverlayFocusRing, useOverlayLightDismiss, useRestoreFocus, useTrapFocus } from "../../overlay";
+import { Underlay, isElementInViewport, useOverlayFocusRing, useOverlayLightDismiss, useRestoreFocus, useTrapFocus } from "../../overlay";
 
 import { CrossButton } from "../../button";
 import { Div } from "../../html";
@@ -110,16 +110,6 @@ function useElementHasVerticalScrollbar(): [MergedRef<HTMLElement>, boolean] {
     ];
 }
 
-// Make sure the autofocus element is in the current viewport to prevent from scrolling down on open.
-function isElementInViewport(element: HTMLElement) {
-    const clientRect = element.getBoundingClientRect();
-
-    return (
-        clientRect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
-        clientRect.right <= (window.innerWidth || document.documentElement.clientWidth)
-    );
-}
-
 export function InnerDialog({
     "aria-describedby": ariaDescribedBy,
     "aria-label": ariaLabel,
@@ -173,6 +163,7 @@ export function InnerDialog({
                 return false;
             }
 
+            // Make sure the autofocus element is in the current viewport to prevent from scrolling down on open.
             if (!isElementInViewport(element)) {
                 return false;
             }

--- a/packages/components/src/overlay/src/index.ts
+++ b/packages/components/src/overlay/src/index.ts
@@ -14,3 +14,4 @@ export * from "./usePopupLightDismiss";
 export * from "./useTriggerWidth";
 export * from "./isTargetParent";
 export * from "./isDevtoolsBlurEvent";
+export * from "./isElementInViewport";

--- a/packages/components/src/overlay/src/isElementInViewport.ts
+++ b/packages/components/src/overlay/src/isElementInViewport.ts
@@ -1,0 +1,11 @@
+export function isElementInViewport(element: HTMLElement) {
+    const rect = element.getBoundingClientRect();
+    const documentElement = document.documentElement;
+
+    return (
+        // Make sure it's visible in the document element.
+        rect.bottom <= documentElement.clientHeight && rect.right <= documentElement.clientWidth &&
+        // Make sure if the user scrolled, it's still visible.
+        rect.bottom >= documentElement.scrollTop && rect.right >= documentElement.scrollLeft
+    );
+}

--- a/packages/components/src/overlay/src/useInteractOutside.ts
+++ b/packages/components/src/overlay/src/useInteractOutside.ts
@@ -16,21 +16,5 @@ export function useInteractOutside(focusScope: FocusScope, { isDisabled, onInter
         }
     });
 
-    // If you remove "capture", test the popover component to make sure it still works.
-    // https://reactjs.org/blog/2020/08/10/react-v17-rc.html#fixing-potential-issues
-    useDocumentListener("click", handleDocumentClick, !isDisabled, { capture: true });
+    useDocumentListener("click", handleDocumentClick, !isDisabled);
 }
-
-// export function useInteractOutside(rootElementRef: RefObject<HTMLElement>, { isDisabled, onInteractOutside }: UseInteractOutsideOptions = {}) {
-//     const handleDocumentClick = useEventCallback(event => {
-//         if (!rootElementRef.current?.contains(event.target as Node)) {
-//             if (!isNil(onInteractOutside)) {
-//                 onInteractOutside(event);
-//             }
-//         }
-//     });
-
-//     // If you remove "capture", test the popover component to make sure it still works.
-//     // https://reactjs.org/blog/2020/08/10/react-v17-rc.html#fixing-potential-issues
-//     useDocumentListener("click", handleDocumentClick, !isDisabled, { capture: true });
-// }

--- a/packages/components/src/overlay/src/useRestoreFocus.ts
+++ b/packages/components/src/overlay/src/useRestoreFocus.ts
@@ -6,6 +6,8 @@
 import { FocusScope, Keys, createFocusableTreeWalker, isNil, useEventCallback, useRefState } from "../../shared";
 import { KeyboardEvent, useLayoutEffect } from "react";
 
+import { isElementInViewport } from "./isElementInViewport";
+
 export interface UseRestoreFocusOptions {
     isDisabled?: boolean;
 }
@@ -90,7 +92,9 @@ export function useRestoreFocus(focusScope: FocusScope, { isDisabled }: UseResto
 
                     requestAnimationFrame(() => {
                         if (document.body.contains(elementToRestore)) {
-                            elementToRestore.focus();
+                            if (isElementInViewport(elementToRestore)) {
+                                elementToRestore.focus();
+                            }
                         }
                     });
                 }

--- a/packages/components/src/overlay/src/useTrapFocus.ts
+++ b/packages/components/src/overlay/src/useTrapFocus.ts
@@ -1,11 +1,7 @@
-import { FocusManager, Keys, isNil, useDisposables, useDocumentListener, useEventCallback, useRefState } from "../../shared";
-
-import { useEffect } from "react";
+import { FocusManager, Keys, isNil, useDocumentListener, useEventCallback, useRefState } from "../../shared";
 
 export function useTrapFocus(focusManager: FocusManager) {
     const [focusedElementRef, setFocusedElement] = useRefState<HTMLElement>();
-
-    const disposables = useDisposables();
 
     const handleKeyDown = useEventCallback((event: KeyboardEvent) => {
         if (event.key === Keys.tab) {
@@ -45,24 +41,7 @@ export function useTrapFocus(focusManager: FocusManager) {
         }
     });
 
-    const handleBlur = useEventCallback((event: FocusEvent) => {
-        // Firefox doesn't shift focus back properly without this.
-        disposables.requestAnimationFrame(() => {
-            if (!focusManager.isInScope(event.relatedTarget as HTMLElement)) {
-                focusedElementRef.current.focus();
-            }
-        });
-    });
-
     // Keydown event listener "useCapture" is set to true to ensure a tab key down is catched before the useRestoreFocus tab key down handler.
     useDocumentListener("keydown", handleKeyDown, true, true);
     useDocumentListener("focusin", handleFocus, true, false);
-
-    useEffect(() => {
-        focusManager.scopeElements.forEach(x => x.addEventListener("focusout", handleBlur, false));
-
-        return () => {
-            focusManager.scopeElements.forEach(x => x.removeEventListener("focusout", handleBlur, false));
-        };
-    }, [focusManager, handleBlur]);
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->


## Summary

- Clicking the trigger of an opened popover wasn't closing the popover anymore
- Updated useRestoreFocus to prevent restoring the focus an element which is not visible in the current viewport. For example, opening a popover at the top of a page, scrolling to the bottom of the page then mouse clicking anywhere to close the popover was scrolling back at the top of the page.

## How to test

- Is this testable with Jest or Chromatic screenshots? No

- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.
