### PR TITLE
Fixed collapsing tab selection can overflow tab list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ For more information on monorepo:
 
 [Lerna](https://github.com/lerna/lerna) is used to manage this monorepo. The packages of the monorepo can be found in the [packages](/packages) directory. 
 
-Exceptionally the website and Storybook are not managed by the monorepo tooling since it's not meant to be published as an npm package. The website can be found in the [website](/website) directory and Storybook can be found in the [storybook](/storybook) directory.
+Exceptionally the website and Storybook are not managed by the monorepo tooling because it's not meant to be published as an npm package. The website can be found in the [website](/website) directory and Storybook can be found in the [storybook](/storybook) directory.
 
 Since Yarn workspace feature offer native mono-repo capabilities and a seemless integration with Lerna this is our goto package manager for this project.
 
@@ -44,13 +44,13 @@ For more information, read the following Lerna commands documentation:
 - [version](https://github.com/lerna/lerna/tree/master/commands/version)
 - [publish](https://github.com/lerna/lerna/tree/master/commands/publish)
 
-This monorepo is configured to release the packages independently. The decision to release or not a package is automatically based on wether the code of the package has changed or not.
+This monorepo is configured to release the packages independently. The decision to release or not a package is based on whether or not the code of the package has changed.
 
 ### Yarn workspace
 
-As mentionned, this monorepo is using Yarn workspace feature to handle the installation of the npm dependencies and manage the packages inter-dependencies.
+This monorepo is using Yarn workspace feature to handle the installation of the npm dependencies and manage the packages inter-dependencies.
 
-It's also important to note that Yarn workspace will **hoist** the npm dependencies at the root of the workspace. This means that there might not be a *node_modules* directory nested in the packages directories. The npm dependencies are installed in a *node_modules* directory at the root of the workspace and a single *yarn.lock* file is generated at the root of the workspace.
+It's important to note that Yarn workspace will **hoist** the npm dependencies at the root of the workspace. This means that there might not be a *node_modules* directory nested in the packages directories. The npm dependencies are installed in a *node_modules* directory at the root of the workspace and a single *yarn.lock* file is generated at the root of the workspace.
 
 Since Storybook is not handled by the monorepo tooling, the [storybook](/storybook) directory will contain a *node_modules* directory and a *yarn.lock* file.
 

--- a/packages/components/src/menu/src/MenuTrigger.tsx
+++ b/packages/components/src/menu/src/MenuTrigger.tsx
@@ -58,12 +58,12 @@ export function InnerMenuTrigger(props: InnerMenuTriggerProps) {
         inputGroupProps
     );
 
-    const [focusTargetRef, setFocusTarget] = useRefState<string>(FocusTarget.first);
+    const [autoFocusTargetRef, setAutoFocusTarget] = useRefState<string>(FocusTarget.first);
 
     const handleOpenChange = useChainedEventCallback(onOpenChange, (event: SyntheticEvent, isVisible: boolean) => {
         // When the menu is closed because of a blur or outside click event, reset the focus target.
         if (!isVisible) {
-            setFocusTarget(FocusTarget.first);
+            setAutoFocusTarget(FocusTarget.first);
         }
     });
 
@@ -90,14 +90,14 @@ export function InnerMenuTrigger(props: InnerMenuTriggerProps) {
     });
 
     const open = useCallback((event: SyntheticEvent, focusTarget: string) => {
-        setFocusTarget(focusTarget);
+        setAutoFocusTarget(focusTarget);
         setIsOpen(event, true);
-    }, [setIsOpen, setFocusTarget]);
+    }, [setIsOpen, setAutoFocusTarget]);
 
     const close = useCallback((event: SyntheticEvent) => {
-        setFocusTarget(null);
+        setAutoFocusTarget(null);
         setIsOpen(event, false);
-    }, [setIsOpen, setFocusTarget]);
+    }, [setIsOpen, setAutoFocusTarget]);
 
     // Open the menu on up & down arrow keydown.
     const handleTriggerKeyDown = useEventCallback((event: KeyboardEvent) => {
@@ -135,7 +135,7 @@ export function InnerMenuTrigger(props: InnerMenuTriggerProps) {
         // Must be conditional to isOpen otherwise it will steal the focus from the trigger when selecting
         // a value because the menu re-render before the exit animation is done.
         autoFocus: isOpen,
-        autoFocusTarget: focusTargetRef.current,
+        autoFocusTarget: autoFocusTargetRef.current,
         onSelectionChange: handleSelectionChange
     });
 

--- a/packages/components/src/select/src/useSelect.ts
+++ b/packages/components/src/select/src/useSelect.ts
@@ -21,7 +21,7 @@ import { useCollection, useOnlyCollectionItems } from "../../collection";
 import { OptionKeyProp } from "../../listbox";
 import { ValidationState } from "../../input";
 
-export interface UseSelectProps {
+export interface UseSelectOptions {
     align?: PopupAlignment;
     allowFlip?: boolean;
     allowPreventOverflow?: boolean;
@@ -32,7 +32,7 @@ export interface UseSelectProps {
     autoFocus?: boolean | number;
     defaultOpen?: boolean;
     defaultSelectedKey?: string;
-    direction: PopupDirection;
+    direction?: PopupDirection;
     disabled?: boolean;
     id?: string;
     onOpenChange?: (event: SyntheticEvent, isOpen: boolean) => void;
@@ -40,7 +40,7 @@ export interface UseSelectProps {
     open?: boolean | null;
     overlayProps?: Partial<OverlayProps>;
     readOnly?: boolean;
-    ref: Ref<any>;
+    ref?: Ref<any>;
     selectedKey?: string | null;
     validationState?: ValidationState;
 }
@@ -67,7 +67,7 @@ export function useSelect(children: ReactNode, {
     ref,
     selectedKey: selectedKeyProp,
     validationState
-}: UseSelectProps) {
+}: UseSelectOptions = {}) {
     const [selectedKey, setSelectedKey] = useControllableState(selectedKeyProp, defaultSelectedKey, null);
     const [focusTargetRef, setFocusTarget] = useRefState<string>(FocusTarget.first);
 

--- a/packages/components/src/select/src/useSelect.ts
+++ b/packages/components/src/select/src/useSelect.ts
@@ -69,12 +69,12 @@ export function useSelect(children: ReactNode, {
     validationState
 }: UseSelectOptions = {}) {
     const [selectedKey, setSelectedKey] = useControllableState(selectedKeyProp, defaultSelectedKey, null);
-    const [focusTargetRef, setFocusTarget] = useRefState<string>(FocusTarget.first);
+    const [autoFocusTargetRef, setAutoFocusTarget] = useRefState<string>(FocusTarget.first);
 
     const handleOpenChange = useChainedEventCallback(onOpenChange, (event: SyntheticEvent, isVisible: boolean) => {
         // When the select is closed because of a blur or outside click event, reset the focus target.
         if (!isVisible) {
-            setFocusTarget(FocusTarget.first);
+            setAutoFocusTarget(FocusTarget.first);
         }
     });
 
@@ -118,9 +118,9 @@ export function useSelect(children: ReactNode, {
     }, [selectedKey, setSelectedKey, onSelectionChange]);
 
     const open = useCallback((event: SyntheticEvent, focusTarget: string) => {
-        setFocusTarget(focusTarget);
+        setAutoFocusTarget(focusTarget);
         setIsOpen(event, true);
-    }, [setIsOpen, setFocusTarget]);
+    }, [setIsOpen, setAutoFocusTarget]);
 
     const close = useCallback((event: SyntheticEvent) => {
         setIsOpen(event, false);
@@ -172,7 +172,7 @@ export function useSelect(children: ReactNode, {
             // Must be conditional to isOpen otherwise it will steal the focus from the trigger when selecting
             // a value because the listbox re-render before the exit animation is done.
             autoFocus: isOpen,
-            autoFocusTarget: focusTargetRef.current,
+            autoFocusTarget: autoFocusTargetRef.current,
             fluid: true,
             focusOnHover: true,
             nodes,

--- a/packages/components/src/shared/src/useFocusScope.ts
+++ b/packages/components/src/shared/src/useFocusScope.ts
@@ -135,7 +135,7 @@ export function useFocusScope(): [FocusScope, (rootElement: HTMLElement) => void
             parseElements();
 
             mutationObserver.observe(rootElement, {
-                attributeFilter: ["style", "class", "hidden"],
+                attributeFilter: ["style", "class", "hidden", "aria-hidden"],
                 attributes: true,
                 childList: true,
                 subtree: true

--- a/packages/components/src/shared/tests/jest/useFocusScope.test.tsx
+++ b/packages/components/src/shared/tests/jest/useFocusScope.test.tsx
@@ -208,6 +208,45 @@ test("when the hidden attribute of an element change, the scope is updated", asy
     await waitFor(() => expect(onScopeChange).toHaveBeenCalledWith([buttonRef.current, textInputRef.current], expect.anything()));
 });
 
+test("when the aria-hidden attribute of an element change, the scope is updated", async () => {
+    let focusScope: FocusScope = null;
+
+    const onScopeChange = jest.fn();
+
+    const buttonRef = createRef<HTMLButtonElement>();
+    const textInputRef = createRef<HTMLInputElement>();
+
+    const { rerender } = render(
+        <Container onInitialScope={scope => { focusScope = scope; }}>
+            <Div>Decoy 1</Div>
+            <Button ref={buttonRef} aria-hidden="true">Button</Button>
+            <Div>Decoy 2</Div>
+            <TextInput placeholder="Value" ref={textInputRef} />
+            <Div>Decoy 3</Div>
+        </Container>
+    );
+
+    await waitFor(() => expect(focusScope).not.toBeNull());
+    await waitFor(() => expect(focusScope.getElements()).not.toContain(buttonRef.current));
+    await waitFor(() => expect(focusScope.getElements()).toContain(textInputRef.current));
+    await waitFor(() => expect(focusScope.getElements().length).toBe(1));
+
+    focusScope.registerChangeHandler(onScopeChange);
+
+    rerender(
+        <Container>
+            <Div>Decoy 1</Div>
+            <Button ref={buttonRef} aria-hidden="false">Button</Button>
+            <Div>Decoy 2</Div>
+            <TextInput placeholder="Value" ref={textInputRef} />
+            <Div>Decoy 3</Div>
+        </Container>
+    );
+
+    await waitFor(() => expect(onScopeChange).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onScopeChange).toHaveBeenCalledWith([buttonRef.current, textInputRef.current], expect.anything()));
+});
+
 test("when the display attribute of an element change, the scope is updated", async () => {
     let focusScope: FocusScope = null;
 

--- a/packages/components/src/tabs/docs/Tabs.stories.mdx
+++ b/packages/components/src/tabs/docs/Tabs.stories.mdx
@@ -218,7 +218,7 @@ A tabs component can handle horizontal overflow by collapsing the overflowing ta
 <Preview>
     <Story name="collapsible">
         <Div width={{ base: "100%", sm: "700px" }}>
-            <Tabs aria-label="Planets">
+            <Tabs fluid aria-label="Planets">
                 <Item key="mars">
                     <Header>Mars</Header>
                     <Content>Mars is a dusty, cold, desert world with a very thin atmosphere. There is strong evidence Mars was—billions of years ago—wetter and warmer, with a thicker atmosphere.</Content>

--- a/packages/components/src/tabs/src/TabList.tsx
+++ b/packages/components/src/tabs/src/TabList.tsx
@@ -27,7 +27,7 @@ import { TabType } from "./useTabsItems";
 import { useCollapsibleTabs } from "./useCollapsibleTabs";
 import { useTabsContext } from "./TabsContext";
 
-const TabGap = 12;
+const TabGap = 8;
 const PopoverTriggerWidth = 48;
 
 interface TabListPopoverProps extends Omit<StyledComponentProps<"button">, "onSelect"> {
@@ -223,7 +223,7 @@ export function InnerTabList({
         target: selectedKey
     });
 
-    const { collapsedTabs, collapsibleTabsRef, visibleTabs } = useCollapsibleTabs(tabs, selectedKey, {
+    const { collapsedTabs, collapsibleTabsRef, hiddenTabs, visibleTabs } = useCollapsibleTabs(tabs, selectedKey, {
         gap: TabGap,
         isDisabled: orientation === "vertical",
         popoverTriggerWidth: PopoverTriggerWidth
@@ -424,7 +424,7 @@ export function InnerTabList({
                 )}
                 {/* Rendering hidden tabs to allow the useCollapsibleTabs hook to calculate the actual size of all the tabs and divide them into visible/collapsed buckets. */}
                 <Div aria-hidden="true" className="o-ui-tab-list-hidden-tabs">
-                    {tabs.map(({
+                    {hiddenTabs.map(({
                         elementType: ElementType = Tab,
                         key,
                         // HACK: removing data-testid prop otherwise the test id will be rendered on the hidden element which will break the Jest tests.

--- a/packages/components/src/tabs/src/useCollapsibleTabs.ts
+++ b/packages/components/src/tabs/src/useCollapsibleTabs.ts
@@ -1,7 +1,7 @@
 // Inspired by: https://codesandbox.io/s/ariakit-collapsible-tab-835t8?file=/src/tab-popover.tsx
 
-import { RefObject, useCallback, useLayoutEffect, useState } from "react";
-import { isNil, useResizeObserver } from "../../shared";
+import { isNil, useMergedRefs, useRefState, useResizeObserver } from "../../shared";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { TabType } from "./useTabsItems";
 
@@ -17,28 +17,16 @@ export function useCollapsibleTabs(tabs: TabType[], selectedKey: string, { gap, 
     const [limit, setLimit] = useState(Infinity);
     const [visibleTabs, setVisibleTabs] = useState(tabs);
     const [collapsedTabs, setCollapsedTabs] = useState<TabType[]>([]);
+    const [isInitialResizeRef, setIsInitialResize] = useRefState(true);
 
-    useLayoutEffect(() => {
-        const newVisibleTabs = tabs.slice(0, limit);
-        let newCollapsedTabs = tabs.slice(limit);
+    const containerRef = useRef<HTMLElement>();
 
-        const selectedTab = newCollapsedTabs.find(x => x.key === selectedKey);
+    const computeLimit = useCallback(() => {
+        const containerElement = containerRef.current;
 
-        if (!isNil(selectedTab)) {
-            const lastVisibleTab = newVisibleTabs.pop();
-
-            newCollapsedTabs = newCollapsedTabs.filter(item => item.key !== selectedKey);
-            newCollapsedTabs.unshift(lastVisibleTab);
-
-            newVisibleTabs.push(selectedTab);
+        if (isNil(containerElement)) {
+            return;
         }
-
-        setVisibleTabs(newVisibleTabs);
-        setCollapsedTabs(newCollapsedTabs);
-    }, [tabs, limit, selectedKey]);
-
-    const handleResize = useCallback((entry, elementRef: RefObject<HTMLElement>) => {
-        const containerElement = elementRef.current;
 
         const availableWidth = containerElement.offsetWidth - popoverTriggerWidth;
         const tabElements = containerElement.querySelectorAll<HTMLElement>("[data-o-ui-type=\"hidden-tab\"]");
@@ -63,11 +51,48 @@ export function useCollapsibleTabs(tabs: TabType[], selectedKey: string, { gap, 
         setLimit(Math.max(MinVisibleItems, i));
     }, [gap, popoverTriggerWidth]);
 
+    // Since a selected collapsed tab is promoted to visible tabs we must recompute the limit when the selectedKey change
+    // because the newly selected tab could be larger than the available space.
+    useEffect(() => {
+        // Must wait for the hidden tabs to be refreshed.
+        requestAnimationFrame(() => {
+            computeLimit();
+        });
+    }, [selectedKey, computeLimit]);
+
+    useLayoutEffect(() => {
+        const newVisibleTabs = tabs.slice(0, limit);
+        let newCollapsedTabs = tabs.slice(limit);
+
+        const selectedTab = newCollapsedTabs.find(x => x.key === selectedKey);
+
+        if (!isNil(selectedTab)) {
+            const lastVisibleTab = newVisibleTabs.pop();
+
+            newCollapsedTabs = newCollapsedTabs.filter(x => x.key !== selectedKey);
+            newCollapsedTabs.unshift(lastVisibleTab);
+
+            newVisibleTabs.push(selectedTab);
+        }
+
+        setVisibleTabs(newVisibleTabs);
+        setCollapsedTabs(newCollapsedTabs);
+    }, [tabs, limit, selectedKey]);
+
+    const handleResize = useCallback(() => {
+        if (isInitialResizeRef.current) {
+            setIsInitialResize(false);
+        } else {
+            computeLimit();
+        }
+    }, [computeLimit, isInitialResizeRef, setIsInitialResize]);
+
     const resizeRef = useResizeObserver(handleResize, { isDisabled: isDisabled || tabs?.length < 2 });
 
     return {
         collapsedTabs,
-        collapsibleTabsRef: resizeRef,
+        collapsibleTabsRef: useMergedRefs(containerRef, resizeRef),
+        hiddenTabs: [...visibleTabs, ...collapsedTabs],
         visibleTabs
     };
 }

--- a/packages/components/src/tabs/src/useCollapsibleTabs.ts
+++ b/packages/components/src/tabs/src/useCollapsibleTabs.ts
@@ -80,6 +80,7 @@ export function useCollapsibleTabs(tabs: TabType[], selectedKey: string, { gap, 
     }, [tabs, limit, selectedKey]);
 
     const handleResize = useCallback(() => {
+        // The initial selected key already trigger a resize, this flag prevent from computing the limit twice at initial render.
         if (isInitialResizeRef.current) {
             setIsInitialResize(false);
         } else {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Issue: https://github.com/gsoft-inc/sg-orbit/issues/846

## Summary

Since a selected collapsed tab is promoted to visible tabs the limit must be re-computed when the selectedKey change because the newly selected tab could be larger than the available space.

## How to test

- Is this testable with Jest or Chromatic screenshots? No

- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.
