### PR TITLE
Feature/popover dismiss fix

### DIFF
--- a/packages/components/src/popover/src/Popover.css
+++ b/packages/components/src/popover/src/Popover.css
@@ -1,7 +1,6 @@
 .o-ui-popover {
     background-color: var(--o-ui-bg-alias-default);
-    padding: var(--o-ui-sp-6);
-    padding-top: var(--o-ui-sp-8);
+    padding: var(--o-ui-sp-4);
     border-radius: var(--o-ui-shape-rounded);
     box-shadow: var(--o-ui-bs-alias-raised);
     /* Must keep a max width. */
@@ -51,11 +50,11 @@
 /* DISMISS BUTTON */
 .o-ui-popover .o-ui-popover-dismiss-button {
     position: absolute;
-    top: 1rem;
-    right: 1rem;
+    top: .25rem;
+    right: .25rem;
 }
 
-/* NOT DISMISSABLE */
-.o-ui-popover-not-dismissable {
-    padding-top: var(--o-ui-sp-6);
+/* DISMISSABLE */
+.o-ui-popover-dismissable .o-ui-popover-header-section {
+    padding-right: var(--o-ui-sp-4);
 }

--- a/packages/components/src/popover/src/Popover.tsx
+++ b/packages/components/src/popover/src/Popover.tsx
@@ -183,7 +183,7 @@ export function InnerPopover({
                         as,
                         className: cssModule(
                             "o-ui-popover",
-                            !dismissable && "not-dismissable"
+                            dismissable && "dismissable"
                         ),
                         id,
                         ref: popoverRef,


### PR DESCRIPTION
Issue: 

## Summary

Close button of a popover was taking too much space, it has been decided to shorten the title when a popover is dismissible and align the middle of the close button with the end of a footer button. As seen here

![image](https://user-images.githubusercontent.com/361632/148805480-60abf1f8-8271-4959-939e-34c394584049.png)

## What I did

Revamped the CSS.