### PR TITLE
Fix badge component style props forward

### DIFF
--- a/packages/components/src/badge/src/Badge.tsx
+++ b/packages/components/src/badge/src/Badge.tsx
@@ -1,7 +1,7 @@
-import { Box } from "../../box";
+import { Box, BoxProps } from "../../box";
 import { Children, ComponentProps, ReactNode, forwardRef } from "react";
-import { Div } from "../../html";
 import { InternalProps, OmitInternalProps, StyledComponentProps, cssModule, mergeProps } from "../../shared";
+
 import { StyleProvider } from "../../styling";
 
 const DefaultElement = "div";
@@ -19,6 +19,10 @@ export interface InnerBadgeProps extends InternalProps, StyledComponentProps<typ
      * The style to use.
      */
     variant?: "count" | "dot" | "icon";
+    /**
+     * Additional props to render on the wrapper element.
+     */
+    wrapperProps?: Partial<BoxProps>;
 }
 
 export function InnerBadge({
@@ -27,6 +31,7 @@ export function InnerBadge({
     forwardedRef,
     overlap,
     variant = "count",
+    wrapperProps: { as: wrapperAs = "div", ...wrapperProps } = {},
     ...rest
 }: InnerBadgeProps) {
     // Not using slots because the overlapped content could also be an icon and thinks get complicated.
@@ -40,15 +45,14 @@ export function InnerBadge({
     return (
         <Box
             {...mergeProps(
-                rest,
+                wrapperProps,
                 {
-                    as,
+                    as: wrapperAs,
                     className: cssModule(
                         "o-ui-badge",
                         variant,
                         overlap && `over-${overlap}`
-                    ),
-                    ref: forwardedRef
+                    )
                 }
             )}
         >
@@ -59,9 +63,18 @@ export function InnerBadge({
                     }
                 }}
             >
-                <Div className="o-ui-badge-anchor">
+                <Box
+                    {...mergeProps(
+                        rest,
+                        {
+                            as,
+                            className: "o-ui-badge-anchor",
+                            ref: forwardedRef
+                        }
+                    )}
+                >
                     {badgeContent}
-                </Div>
+                </Box>
             </StyleProvider>
             {overlappedElement}
         </Box>

--- a/packages/components/src/badge/tests/chromatic/Badge.chroma.jsx
+++ b/packages/components/src/badge/tests/chromatic/Badge.chroma.jsx
@@ -1,5 +1,6 @@
-import { Badge } from "@components/badge";
 import { CheckCircleIcon, EmailIcon } from "@components/icons";
+
+import { Badge } from "@components/badge";
 import { Div } from "@components/html";
 import { Inline } from "@components/layout";
 import { Text } from "@components/typography";
@@ -27,7 +28,7 @@ function CircleBadge({ children, ...rest }) {
             overlap="circle"
         >
             {children}
-            <Div backgroundColor="alias-accent" borderRadius="100" width={6} height={6} />
+            <Div backgroundColor="alias-accent" borderRadius="100px" width={6} height={6} />
         </Badge>
     );
 }


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Part of https://github.com/gsoft-inc/sg-orbit/issues/862 (this is the 3))

## Summary

Badge style props were not forwarded to the badge but were instead rendered on the wrapper element.

## What I did

- Forward style props to the badge
- Added a `wrapperProps` to allow a user to set props on the wrapper element

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes

- Does this need an update to the documentation? No
