### PR TITLE
fluid button w/ icon margin negative fix / chromatic tests adjustments

### DIFF
--- a/packages/components/src/button/src/TextButton.css
+++ b/packages/components/src/button/src/TextButton.css
@@ -31,6 +31,7 @@
     margin-right: calc(-1 * (var(--o-ui-text-button-with-icon-padding-md) + var(--o-ui-text-button-icon-size-md)) / 2);
 }
 
+.o-ui-button-fluid.o-ui-button-has-end-icon.o-ui-button-has-start-icon.o-ui-button-sm .o-ui-button-text,
 .o-ui-button-fluid.o-ui-button-has-end-icon.o-ui-button-has-start-icon.o-ui-button-md .o-ui-button-text {
     margin-left: 0;
     margin-right: 0;

--- a/packages/components/src/button/src/TextButton.css
+++ b/packages/components/src/button/src/TextButton.css
@@ -3,8 +3,10 @@
 .o-ui-text-button {
     --o-ui-text-button-padding-sm: var(--o-ui-sp-3);
     --o-ui-text-button-padding-md: var(--o-ui-sp-4);
-    --o-ui-text-button-padding-sm: var(--o-ui-sp-3);
-    --o-ui-text-button-padding-md: var(--o-ui-sp-4);
+    --o-ui-text-button-with-icon-padding-sm: var(--o-ui-sp-2);
+    --o-ui-text-button-with-icon-padding-md: var(--o-ui-sp-3);
+    --o-ui-text-button-icon-size-sm: 1rem;
+    --o-ui-text-button-icon-size-md: 1.25rem;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -21,12 +23,25 @@
     margin-left: var(--o-ui-sp-1);
 }
 
-.o-ui-button-fluid:not(.o-ui-button-has-start-icon).o-ui-button-sm {
-    padding-left: calc(var(--o-ui-sp-2) + var(--o-ui-sp-4));
+.o-ui-button-fluid.o-ui-button-has-start-icon.o-ui-button-md .o-ui-button-text {
+    margin-left: calc(-1 * (var(--o-ui-text-button-with-icon-padding-md) + var(--o-ui-text-button-icon-size-md)) / 2);
 }
 
-.o-ui-button-fluid:not(.o-ui-button-has-start-icon).o-ui-button-md {
-    padding-left: calc(var(--o-ui-sp-3) + var(--o-ui-sp-5));
+.o-ui-button-fluid.o-ui-button-has-end-icon.o-ui-button-md .o-ui-button-text {
+    margin-right: calc(-1 * (var(--o-ui-text-button-with-icon-padding-md) + var(--o-ui-text-button-icon-size-md)) / 2);
+}
+
+.o-ui-button-fluid.o-ui-button-has-end-icon.o-ui-button-has-start-icon.o-ui-button-md .o-ui-button-text {
+    margin-left: 0;
+    margin-right: 0;
+}
+
+.o-ui-button-fluid.o-ui-button-has-start-icon.o-ui-button-sm .o-ui-button-text {
+    margin-left: calc(-1 * (var(--o-ui-text-button-with-icon-padding-sm) + var(--o-ui-text-button-icon-size-sm)) / 2);
+}
+
+.o-ui-button-fluid.o-ui-button-has-end-icon.o-ui-button-sm .o-ui-button-text {
+    margin-right: calc(-1 * (var(--o-ui-text-button-with-icon-padding-sm) + var(--o-ui-text-button-icon-size-sm)) / 2);
 }
 
 /* SIZES */
@@ -41,18 +56,18 @@
 /* CONTENT | ICON | SIZES */
 /* LEFT */
 .o-ui-text-button.o-ui-button-has-start-icon.o-ui-button-sm {
-    padding-left: var(--o-ui-sp-2);
+    padding-left: var(--o-ui-text-button-with-icon-padding-sm);
 }
 
 .o-ui-text-button.o-ui-button-has-start-icon.o-ui-button-md {
-    padding-left: var(--o-ui-sp-3);
+    padding-left: var(--o-ui-text-button-with-icon-padding-md);
 }
 
 /* RIGHT */
 .o-ui-text-button.o-ui-button-has-end-icon.o-ui-button-sm {
-    padding-right: var(--o-ui-sp-2);
+    padding-right: var(--o-ui-text-button-with-icon-padding-sm);
 }
 
 .o-ui-text-button.o-ui-button-has-end-icon.o-ui-button-md {
-    padding-right: var(--o-ui-sp-3);
+    padding-right: var(--o-ui-text-button-with-icon-padding-md);
 }

--- a/packages/components/src/button/tests/chromatic/createButtonTestSuite.jsx
+++ b/packages/components/src/button/tests/chromatic/createButtonTestSuite.jsx
@@ -88,12 +88,15 @@ export function createButtonTestSuite(element, stories) {
                         <Text>Button</Text>
                     </Button>
                 </Div>
-                <Div>
+                <Stack>
                     <Button fluid element={element}>
                         <SignoutIcon />
                         <Text>Button</Text>
                     </Button>
-                </Div>
+                    <Button fluid element={element}>
+                        <Text>Button</Text>
+                    </Button>
+                </Stack>
             </Stack>
         )
         .add("end icon", () =>
@@ -148,12 +151,15 @@ export function createButtonTestSuite(element, stories) {
                         <SignoutIcon slot="end-icon" />
                     </Button>
                 </Div>
-                <Div>
+                <Stack>
                     <Button fluid element={element}>
                         <Text>Button</Text>
                         <SignoutIcon slot="end-icon" />
                     </Button>
-                </Div>
+                    <Button fluid element={element}>
+                        <Text>Button</Text>
+                    </Button>
+                </Stack>
             </Stack>
         )
         .add("counter", () =>


### PR DESCRIPTION
Issue: 

#924 

## Summary

Text in a fluid button was not exactly centered when a start or end-icon was present.

## What I did

When a fluid button has a start icon we are offsetting it's margin-left negatively to compensate the space taken by the icon.

When a fluid button has an end icon we are offsetting it's margin-left negatively to compensate the space taken by the icon.

## How to test

/?path=/story/chromatic-button-negative--icon