### PR TITLE
Added css to placeholder in order to make Safari placeholder font-size the same as others browsers

### DIFF
--- a/packages/components/src/input/src/Input.css
+++ b/packages/components/src/input/src/Input.css
@@ -72,6 +72,7 @@
 .o-ui-input textarea::placeholder {
     color: var(--o-ui-text-alias-input-placeholder);
     opacity: 1;
+    font-size: var(--o-ui-fs-3);
 }
 
 .o-ui-input input:disabled::placeholder,


### PR DESCRIPTION
Issue: 

## Summary

This aim to fix issue #932 

## What I did

Added a specific rule on the placeholder style declaration.

## How to test

Using Safari visit : /?path=/docs/text-input--default-story