### PR TITLE
added background color to input wrapper

### DIFF
--- a/packages/components/src/input/src/adaptInputStylingProps.ts
+++ b/packages/components/src/input/src/adaptInputStylingProps.ts
@@ -16,6 +16,7 @@ type WrapperStyledSystemProps =
     "alignContent" |
     "alignItems" |
     "alignSelf" |
+    "backgroundColor" |
     "border" |
     "borderActive" |
     "borderBottom" |
@@ -125,6 +126,7 @@ function moveStyledSystemPropsToWrapper<TProps extends Record<string, any>>({ wr
         alignContent,
         alignItems,
         alignSelf,
+        backgroundColor,
         border,
         borderActive,
         borderBottom,
@@ -234,6 +236,7 @@ function moveStyledSystemPropsToWrapper<TProps extends Record<string, any>>({ wr
         alignContent,
         alignItems,
         alignSelf,
+        backgroundColor,
         border,
         borderActive,
         borderBottom,

--- a/packages/components/src/input/src/adaptInputStylingProps.ts
+++ b/packages/components/src/input/src/adaptInputStylingProps.ts
@@ -17,6 +17,9 @@ type WrapperStyledSystemProps =
     "alignItems" |
     "alignSelf" |
     "backgroundColor" |
+    "backgroundColorActive" |
+    "backgroundColorFocus" |
+    "backgroundColorHover" |
     "border" |
     "borderActive" |
     "borderBottom" |
@@ -127,6 +130,9 @@ function moveStyledSystemPropsToWrapper<TProps extends Record<string, any>>({ wr
         alignItems,
         alignSelf,
         backgroundColor,
+        backgroundColorActive,
+        backgroundColorFocus,
+        backgroundColorHover,
         border,
         borderActive,
         borderBottom,
@@ -237,6 +243,9 @@ function moveStyledSystemPropsToWrapper<TProps extends Record<string, any>>({ wr
         alignItems,
         alignSelf,
         backgroundColor,
+        backgroundColorActive,
+        backgroundColorFocus,
+        backgroundColorHover,
         border,
         borderActive,
         borderBottom,


### PR DESCRIPTION
Issue: 

## Summary

When passing a backgroundColor style prop the input was receiving the value, not the wrapper this PR aims at fixing this problematic.

## What I did

Added backgroundColor to adaptInputStylingProps.