### PR TITLE
revamped modal copy to match image

### DIFF
--- a/packages/components/src/modal/docs/Modal.stories.mdx
+++ b/packages/components/src/modal/docs/Modal.stories.mdx
@@ -50,10 +50,10 @@ A modal must have an heading and a content.
         <ModalTrigger>
             <Button variant="secondary">Open</Button>
             <Modal>
-                <Heading>Apollo 11 movie</Heading>
+                <Heading>Cloud City</Heading>
                 <Content>
-                    <Paragraph>Apollo 11 is a 2019 American documentary film edited, produced and directed by Todd Douglas Miller. It focuses on the 1969 Apollo 11 mission, the first spaceflight from which men walked on the Moon.</Paragraph>
-                    <Paragraph>The film consists solely of archival footage, including 70 mm film previously unreleased to the public, and does not feature narration, interviews or modern recreations. The Saturn V rocket, Apollo crew consisting of Buzz Aldrin, Neil Armstrong, and Michael Collins, and Apollo program Earth-based mission operations engineers are prominently featured in the film.</Paragraph>
+                    <Paragraph>Cloud City was a completely man-made tibanna gas mining colony staff hovering over the gas giant Bespin, occupied by millions of workers, tourists and support staff. Located in Bespin's Life Zone, the station had no need for airlocks or life support systems, with the atmosphere comprised mostly of oxygen and acceptable levels of gravity and temperature.</Paragraph>
+                    <Paragraph>The station was situated 59,000 kilometers above Bespin's core, while its disk was approximately 16.2 kilometers in diameter. 36,000 repulsorlift engines and tractor beam generators kept the giant city floating above the planet. It contained 392 levels, along with platforms and rooms for residents and visitors.</Paragraph>
                 </Content>
             </Modal>
         </ModalTrigger>
@@ -69,11 +69,11 @@ A modal can have a side banner [image](?path=/story/chromatic-image--default). M
         <ModalTrigger>
             <Button variant="secondary">Open</Button>
             <Modal>
-                <Image src={{ base: SpacePortraitHorizontal, sm: SpacePortrait }} alt="Planet with a flag" />
-                <Heading>Apollo 11 movie</Heading>
+                <Image src={{ base: SpacePortraitHorizontal, sm: SpacePortrait }} alt="City over clouds" />
+                <Heading>Cloud City</Heading>
                 <Content>
-                    <Paragraph>Apollo 11 is a 2019 American documentary film edited, produced and directed by Todd Douglas Miller. It focuses on the 1969 Apollo 11 mission, the first spaceflight from which men walked on the Moon.</Paragraph>
-                    <Paragraph>The film consists solely of archival footage, including 70 mm film previously unreleased to the public, and does not feature narration, interviews or modern recreations. The Saturn V rocket, Apollo crew consisting of Buzz Aldrin, Neil Armstrong, and Michael Collins, and Apollo program Earth-based mission operations engineers are prominently featured in the film.</Paragraph>
+                    <Paragraph>Cloud City was a completely man-made tibanna gas mining colony staff hovering over the gas giant Bespin, occupied by millions of workers, tourists and support staff. Located in Bespin's Life Zone, the station had no need for airlocks or life support systems, with the atmosphere comprised mostly of oxygen and acceptable levels of gravity and temperature.</Paragraph>
+                    <Paragraph>The station was situated 59,000 kilometers above Bespin's core, while its disk was approximately 16.2 kilometers in diameter. 36,000 repulsorlift engines and tractor beam generators kept the giant city floating above the planet. It contained 392 levels, along with platforms and rooms for residents and visitors.</Paragraph>
                 </Content>
             </Modal>
         </ModalTrigger>
@@ -90,10 +90,10 @@ Or an [illustration](?path=/docs/illustration--horizontal). Prefer 1:1 ratio for
                 <Illustration backgroundColor="alias-accent-light">
                     <Image src={Planet} alt="Planet Logo" />
                 </Illustration>
-                <Heading>Apollo 11</Heading>
+                <Heading>Cloud City</Heading>
                 <Content>
-                    <Paragraph>Apollo 11 was the spaceflight that first landed humans on the Moon. Commander Neil Armstrong and lunar module pilot Buzz Aldrin formed the American crew that landed the Apollo Lunar Module Eagle on July 20, 1969, at 20:17 UTC.</Paragraph>
-                    <Paragraph>Armstrong became the first person to step onto the lunar surface six hours and 39 minutes later on July 21 at 02:56 UTC; Aldrin joined him 19 minutes later. They spent about two and a quarter hours together outside the spacecraft, and collected 47.5 pounds (21.5 kg) of lunar material to bring back to Earth. Command module pilot Michael Collins flew the Command Module Columbia alone in lunar orbit while they were on the Moon's surface. Armstrong and Aldrin spent 21 hours, 36 minutes on the lunar surface, at a site they had named Tranquility Base upon landing, before lifting off to rejoin Columbia in lunar orbit.</Paragraph>
+                    <Paragraph>Cloud City was a completely man-made tibanna gas mining colony staff hovering over the gas giant Bespin, occupied by millions of workers, tourists and support staff. Located in Bespin's Life Zone, the station had no need for airlocks or life support systems, with the atmosphere comprised mostly of oxygen and acceptable levels of gravity and temperature.</Paragraph>
+                    <Paragraph>The station was situated 59,000 kilometers above Bespin's core, while its disk was approximately 16.2 kilometers in diameter. 36,000 repulsorlift engines and tractor beam generators kept the giant city floating above the planet. It contained 392 levels, along with platforms and rooms for residents and visitors.</Paragraph>
                 </Content>
             </Modal>
         </ModalTrigger>
@@ -138,13 +138,13 @@ Use an header to provide additional information usually in the form of a link or
         <ModalTrigger>
             <Button variant="secondary">Open</Button>
             <Modal>
-                <Heading>Apollo 11 movie</Heading>
+                <Heading>Cloud City</Heading>
                 <Header>
-                    <TextLink href="https://en.wikipedia.org/wiki/Apollo_11_(2019_film)" external>Wikipedia</TextLink>
+                    <TextLink href="https://en.wikipedia.org/wiki/Floating_cities_and_islands_in_fiction" external>Wikipedia</TextLink>
                 </Header>
                 <Content>
-                    <Paragraph>Apollo 11 is a 2019 American documentary film edited, produced and directed by Todd Douglas Miller. It focuses on the 1969 Apollo 11 mission, the first spaceflight from which men walked on the Moon.</Paragraph>
-                    <Paragraph>The film consists solely of archival footage, including 70 mm film previously unreleased to the public, and does not feature narration, interviews or modern recreations. The Saturn V rocket, Apollo crew consisting of Buzz Aldrin, Neil Armstrong, and Michael Collins, and Apollo program Earth-based mission operations engineers are prominently featured in the film.</Paragraph>
+                    <Paragraph>Cloud City was a completely man-made tibanna gas mining colony staff hovering over the gas giant Bespin, occupied by millions of workers, tourists and support staff. Located in Bespin's Life Zone, the station had no need for airlocks or life support systems, with the atmosphere comprised mostly of oxygen and acceptable levels of gravity and temperature.</Paragraph>
+                    <Paragraph>The station was situated 59,000 kilometers above Bespin's core, while its disk was approximately 16.2 kilometers in diameter. 36,000 repulsorlift engines and tractor beam generators kept the giant city floating above the planet. It contained 392 levels, along with platforms and rooms for residents and visitors.</Paragraph>
                 </Content>
             </Modal>
         </ModalTrigger>
@@ -160,10 +160,10 @@ Use a footer to provide trivial information about content present in the modal, 
         <ModalTrigger>
             <Button variant="secondary">Open</Button>
             <Modal>
-                <Heading>Apollo 11 movie</Heading>
+                <Heading>Cloud City</Heading>
                 <Content>
-                    <Paragraph>Apollo 11 is a 2019 American documentary film edited, produced and directed by Todd Douglas Miller. It focuses on the 1969 Apollo 11 mission, the first spaceflight from which men walked on the Moon.</Paragraph>
-                    <Paragraph>The film consists solely of archival footage, including 70 mm film previously unreleased to the public, and does not feature narration, interviews or modern recreations. The Saturn V rocket, Apollo crew consisting of Buzz Aldrin, Neil Armstrong, and Michael Collins, and Apollo program Earth-based mission operations engineers are prominently featured in the film.</Paragraph>
+                    <Paragraph>Cloud City was a completely man-made tibanna gas mining colony staff hovering over the gas giant Bespin, occupied by millions of workers, tourists and support staff. Located in Bespin's Life Zone, the station had no need for airlocks or life support systems, with the atmosphere comprised mostly of oxygen and acceptable levels of gravity and temperature.</Paragraph>
+                    <Paragraph>The station was situated 59,000 kilometers above Bespin's core, while its disk was approximately 16.2 kilometers in diameter. 36,000 repulsorlift engines and tractor beam generators kept the giant city floating above the planet. It contained 392 levels, along with platforms and rooms for residents and visitors.</Paragraph>
                 </Content>
                 <Footer>Copyright 2021</Footer>
             </Modal>
@@ -180,10 +180,10 @@ A modal can have a single [button](?path=/docs/button--default-story). Use a pri
         <ModalTrigger>
             <Button variant="secondary">Open</Button>
             <Modal>
-                <Heading>Apollo 11 movie</Heading>
+                <Heading>Cloud City</Heading>
                 <Content>
-                    <Paragraph>Apollo 11 is a 2019 American documentary film edited, produced and directed by Todd Douglas Miller. It focuses on the 1969 Apollo 11 mission, the first spaceflight from which men walked on the Moon.</Paragraph>
-                    <Paragraph>The film consists solely of archival footage, including 70 mm film previously unreleased to the public, and does not feature narration, interviews or modern recreations. The Saturn V rocket, Apollo crew consisting of Buzz Aldrin, Neil Armstrong, and Michael Collins, and Apollo program Earth-based mission operations engineers are prominently featured in the film.</Paragraph>
+                    <Paragraph>Cloud City was a completely man-made tibanna gas mining colony staff hovering over the gas giant Bespin, occupied by millions of workers, tourists and support staff. Located in Bespin's Life Zone, the station had no need for airlocks or life support systems, with the atmosphere comprised mostly of oxygen and acceptable levels of gravity and temperature.</Paragraph>
+                    <Paragraph>The station was situated 59,000 kilometers above Bespin's core, while its disk was approximately 16.2 kilometers in diameter. 36,000 repulsorlift engines and tractor beam generators kept the giant city floating above the planet. It contained 392 levels, along with platforms and rooms for residents and visitors.</Paragraph>
                 </Content>
                 <Button>Choose</Button>
             </Modal>
@@ -198,10 +198,10 @@ Or a [group of button](?path=/docs/button--default-story#button-group). A maximu
         <ModalTrigger>
             <Button variant="secondary">Open</Button>
             <Modal>
-                <Heading>Apollo 11 movie</Heading>
+                <Heading>Cloud City</Heading>
                 <Content>
-                    <Paragraph>Apollo 11 is a 2019 American documentary film edited, produced and directed by Todd Douglas Miller. It focuses on the 1969 Apollo 11 mission, the first spaceflight from which men walked on the Moon.</Paragraph>
-                    <Paragraph>The film consists solely of archival footage, including 70 mm film previously unreleased to the public, and does not feature narration, interviews or modern recreations. The Saturn V rocket, Apollo crew consisting of Buzz Aldrin, Neil Armstrong, and Michael Collins, and Apollo program Earth-based mission operations engineers are prominently featured in the film.</Paragraph>
+                    <Paragraph>Cloud City was a completely man-made tibanna gas mining colony staff hovering over the gas giant Bespin, occupied by millions of workers, tourists and support staff. Located in Bespin's Life Zone, the station had no need for airlocks or life support systems, with the atmosphere comprised mostly of oxygen and acceptable levels of gravity and temperature.</Paragraph>
+                    <Paragraph>The station was situated 59,000 kilometers above Bespin's core, while its disk was approximately 16.2 kilometers in diameter. 36,000 repulsorlift engines and tractor beam generators kept the giant city floating above the planet. It contained 392 levels, along with platforms and rooms for residents and visitors.</Paragraph>
                 </Content>
                 <ButtonGroup>
                     <Button variant="secondary">Select</Button>


### PR DESCRIPTION
Issue: 

## Summary

#949 Modal doc text does not fit image example

## What I did

Modified the copy and wikipedia link to better reflect the image presented in the Modal image sample.