### PR TITLE
reorganized structure of components docs

### DIFF
--- a/packages/components/src/accordion/docs/Accordion.stories.mdx
+++ b/packages/components/src/accordion/docs/Accordion.stories.mdx
@@ -21,11 +21,12 @@ import { InnerItem, Item } from "@components/collection";
     githubPath="/packages/components/src/accordion/src"
 />
 
-## Accessibility
+## Guidelines
 
-The accordion header that shows and hides the content must be an [heading element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements).
+### Accessibility
 
-That heading element should have a level that is appropriate for the information architecture of the page. You can choose the appropriate level by selecting one of Orbit heading element accordingly.
+- The accordion header that shows and hides the content must be an [heading element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements).
+- The heading element should have a level that is appropriate for the information architecture of the page. You can choose the appropriate level by selecting one of Orbit heading element accordingly.
 
 ## Usage
 

--- a/packages/components/src/alert/docs/Alert.stories.mdx
+++ b/packages/components/src/alert/docs/Alert.stories.mdx
@@ -20,9 +20,11 @@ import { Heading, InnerHeading } from "@components/typography";
     githubPath="/packages/components/src/alert/src"
 />
 
-## Accessibility
+## Guidelines
 
-An alert comes with the `alertdialog` role and should be used to display a confirmation message, an alert, an error, or a warning.
+### Accessibility
+
+- An alert comes with the `alertdialog` role and should be used to display a confirmation message, an alert, an error, or a warning.
 
 It requires:
 - The focus to be trapped inside the alert.
@@ -32,7 +34,7 @@ It requires:
 
 Label and description can be overwritten with the use of `aria-label` and `aria-describedby` props on the alert.
 
-### Focus
+#### Focus
 
 If the alert calls for an action, make sure to set the focus correctly to avoid any unwanted action.
 To do so, you can use the `autoFocusButton` prop on the alert to specify which control should have the initial focus.

--- a/packages/components/src/disclosure/docs/Disclosure.stories.mdx
+++ b/packages/components/src/disclosure/docs/Disclosure.stories.mdx
@@ -21,9 +21,11 @@ import { Text } from "@components/typography";
     githubPath="/packages/components/src/disclosure/src"
 />
 
-## Accessibility
+## Guidelines
 
-The disclosure's trigger that shows and hides the content must be a [button element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button) or have the [role button](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role).
+### Accessibility
+
+- The disclosure's trigger that shows and hides the content must be a [button element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button) or have the [role button](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role).
 
 ## Usage
 

--- a/packages/components/src/field/docs/Field.stories.mdx
+++ b/packages/components/src/field/docs/Field.stories.mdx
@@ -19,9 +19,11 @@ import { TextInput } from "@components/text-input";
     githubPath="/packages/components/src/field/src"
 />
 
-## Accessibility
+## Disclosure
 
-When combined with a [form](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) element, a field component follows the [WAI specifications for forms](https://www.w3.org/WAI/tutorials/forms/).
+### Accessibility
+
+- When combined with a [form](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form) element, a field component follows the [WAI specifications for forms](https://www.w3.org/WAI/tutorials/forms/).
 
 ## Usage
 

--- a/packages/components/src/form/docs/Form.stories.mdx
+++ b/packages/components/src/form/docs/Form.stories.mdx
@@ -21,9 +21,11 @@ import { PasswordInput, TextInput } from "@components/text-input";
     githubPath="/packages/components/src/form/src"
 />
 
-## Accessibility
+## Guidelines
 
-When combined with [field](?path=/story/field--input) components, a form component follows the [WAI specifications for forms](https://www.w3.org/WAI/tutorials/forms/).
+### Accessibility
+
+- When combined with [field](?path=/story/field--input) components, a form component follows the [WAI specifications for forms](https://www.w3.org/WAI/tutorials/forms/).
 
 ## Usage
 

--- a/packages/components/src/icons/docs/Icon.stories.mdx
+++ b/packages/components/src/icons/docs/Icon.stories.mdx
@@ -19,9 +19,11 @@ import IndexFileUsage from "./IndexFileUsage.mdx";
     githubPath="/packages/components/src/icons/src"
 />
 
-## Accessibility
+## Guidelines
 
-When applicable, an accessible name should be provided through `aria-label` to indicate the **purpose** of the icon in it's **current context**. For more information see [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute).
+### Accessibility
+
+- When applicable, an accessible name should be provided through `aria-label` to indicate the **purpose** of the icon in it's **current context**. For more information see [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute).
 
 ## Usage
 

--- a/packages/components/src/image/docs/Image.stories.mdx
+++ b/packages/components/src/image/docs/Image.stories.mdx
@@ -18,9 +18,11 @@ import { Inline } from "@components/layout";
     githubPath="/packages/components/src/image/src"
 />
 
-## Accessibility
+## Guidelines
 
-An image must have an `alt` attribute.
+### Accessibility
+
+- An image must have an `alt` attribute.
 
 ## Usage
 

--- a/packages/components/src/listbox/docs/Listbox.stories.mdx
+++ b/packages/components/src/listbox/docs/Listbox.stories.mdx
@@ -23,9 +23,11 @@ import { Tooltip, TooltipTrigger } from "@components/tooltip";
     githubPath="/packages/components/src/listbox/src"
 />
 
-## Accessibility
+## Guidelines
 
-A listbox should have an `aria-label` prop describing the content of the list.
+### Accessibility
+
+- A listbox should have an `aria-label` prop describing the content of the list.
 
 ## Usage
 

--- a/packages/components/src/lozenge/docs/Lozenge.stories.mdx
+++ b/packages/components/src/lozenge/docs/Lozenge.stories.mdx
@@ -19,28 +19,27 @@ import { Text } from "@components/typography";
     githubPath="/packages/components/src/lozenge/src"
 />
 
-## Best practices
 
-Lozenge should:
+## Guidelines
 
-- Be used to highlight an element in a list.
-- Be used to bring attention to a particular element that requires the user’s attention, such as an expiring license, something new or a problematic situation.
-- Be non-interactive, this includes being clickable or trigger a tooltip on hover.
+### When to use
 
-## Content guidelines
+- To highlight an element in a list.
+- To bring attention to a particular element that requires the user’s attention, such as an expiring license, something new or a problematic situation.
+
+### Content guidelines
 
 - Keep the copy short, ideally only 1 word or 2 short words. If you need to display more text, you should consider using another component such as a [message](?path=/docs/message--default-story) or an [alert](?path=/docs/alert--default-story).
-
-
-## Accessibility
-
 - Text should be descriptive enough to be understood without relying on the color.
-- Text should be descriptive and complete enough to be understood without relying on an icon. Using an icon to carry information will render it non-accessible.
+- Lozenge should be non-interactive, this includes being clickable or trigger a tooltip on hover.
 
-## Related
+### Accessibility
 
-- To display a quantity, use either a [counter](?path=/docs/counter--default-story) or a [badge](?path=/docs/badge--default-story).
-- To provide contextual help, use a [tooltip](?path=/docs/tooltip--default-story).
+- Text should be descriptive enough to be understood without relying on an icon. Using an icon to carry information will render it non-accessible.
+
+### Lozenge vs Counter vs Badge
+
+- Lozenges are for text copy when you want to display a quantity, use either a [counter](?path=/docs/counter--default-story) or a [badge](?path=/docs/badge--default-story).
 
 ## Usage
 

--- a/packages/components/src/modal/docs/Modal.stories.mdx
+++ b/packages/components/src/modal/docs/Modal.stories.mdx
@@ -26,18 +26,28 @@ import { TextLink } from "@components/link";
     githubPath="/packages/components/src/modal/src"
 />
 
-## Best Practices
+## Guidelines
 
-- Prefer dismissible modal whenever possible. If your modal has no way to be dismissed and depends on a user choice use an [Alert](?path=/docs/alert--default-story).
-- Modals can be disruptive, use them sparingly.
+### When to use
+
+- Use a Modal when you want a user to interact with the application without jumping to a new page and interrupting the user's workflow.
+
+### Content
+
 - Modals should not have complex layouts, these are not pages, when in need in more than a choice layout, use an appropriate [component](#related-components) or a page.
-- Don’t ask a question right above the buttons.
-
-## Accessibility
-
+- Don’t ask the user a question right above the buttons.
 - Modal should not rely on images or illustrations in order to give information to the user.
 - When presenting [choices](#choice) a Modal should provide enough information for the user to be able to take a decision in the spot, or a way to come back to the choice later.
+
+### Accessibility
+
 - Focus on the first interactive element in the modal, except if it’s a destructive action as it could trigger unwanted behavior.
+- Prefer dismissible modal whenever possible.
+- Modals can be disruptive, use them sparingly.
+
+### Modal vs Alert
+
+If your modal has no way to be dismissed and depends on a user choice use an [Alert](?path=/docs/alert--default-story).
 
 ## Usage
 

--- a/packages/components/src/select/docs/Select.stories.mdx
+++ b/packages/components/src/select/docs/Select.stories.mdx
@@ -22,9 +22,11 @@ import { Tooltip, TooltipTrigger } from "@components/tooltip";
     githubPath="/packages/components/src/select/src"
 />
 
-## Accessibility
+## Guidelines
 
-If you choose to provide an `aria-label` attribute, please make sure you update the value to match the selected value otherwise screen readers won't be able to anounce the selected value.
+### Accessibility
+
+- If you choose to provide an `aria-label` attribute, please make sure you update the value to match the selected value otherwise screen readers won't be able to anounce the selected value.
 
 ## Usage
 

--- a/packages/components/src/tabs/docs/Tabs.stories.mdx
+++ b/packages/components/src/tabs/docs/Tabs.stories.mdx
@@ -23,9 +23,11 @@ import { Text } from "@components/typography";
     githubPath="/packages/components/src/tabs/src"
 />
 
-## Accessibility
+## Guidelines
 
-An accessible title must be provided through aria-label prop. See [WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/#wai-aria-roles-states-and-properties-20).
+### Accessibility
+
+- An accessible title must be provided through aria-label prop. See [WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/#wai-aria-roles-states-and-properties-20).
 
 ## Usage
 


### PR DESCRIPTION
Issue: 

## Summary

Fixed issue #958, a new doc structure is making it's way in Orbit and most components were not using it.

## What I did

Where necessary the Guidelines sections has been added. Accessibility has been moved to a lower tier hierarchy and split when tips were actually more content guidelines.

## How to test

Visit these pages

- Lozenge
- Alert
- Accordion
- Tabs
- Select
- Listbox
- Disclosure
- Field
- Form
- Icon
- Image
- Modal
- Switch