### PR TITLE
removed text transform on lozenge / added a test for text transform on a lozenge

### DIFF
--- a/packages/components/src/lozenge/docs/Lozenge.stories.mdx
+++ b/packages/components/src/lozenge/docs/Lozenge.stories.mdx
@@ -31,7 +31,7 @@ import { Text } from "@components/typography";
 
 Lozenges should:
 
-- Be concise, 1 word or 2 short words is the optimal length.
+- Be concise, 1 or 2 short words is the optimal length.
 - Be descriptive enough to be understood without relying on a color or an icon.
 - Be non-interactive, this includes being clickable or triggering a tooltip on hover.
 - Refrain from using punctuation like `!` or `?`.
@@ -60,7 +60,7 @@ An [icon](?path=/docs/icon-gallery--page) is used to make it easier for the user
     <Story name="icon">
         <Lozenge>
             <CheckCircleIcon />
-            <Text>New</Text>
+            <Text>NEW</Text>
         </Lozenge>
     </Story>
 </Preview>
@@ -72,8 +72,8 @@ The lozenge can be used in small version to accommodate smaller spaces, such as 
 <Preview>
     <Story name="size">
         <Inline alignY="center">
-            <Lozenge size="sm">New</Lozenge>
-            <Lozenge>New</Lozenge>
+            <Lozenge size="sm">NEW</Lozenge>
+            <Lozenge>NEW</Lozenge>
         </Inline>
     </Story>
 </Preview>
@@ -86,8 +86,8 @@ A lozenge can be highlighted to bring more attention to it when required. This v
 <Preview>
     <Story name="highlight">
         <Inline alignY="center">
-            <Lozenge size="sm" highlight>New</Lozenge>
-            <Lozenge highlight>New</Lozenge>
+            <Lozenge size="sm" highlight>NEW</Lozenge>
+            <Lozenge highlight>NEW</Lozenge>
         </Inline>
     </Story>
 </Preview>

--- a/packages/components/src/lozenge/src/Lozenge.css
+++ b/packages/components/src/lozenge/src/Lozenge.css
@@ -3,13 +3,18 @@
     align-items: center;
     background-color: var(--o-ui-bg-alias-accent-light);
     color: var(--o-ui-text-alias-primary);
-    text-transform: uppercase;
     padding: 0 var(--o-ui-sp-2);
     border-radius: 4px;
+    font-variation-settings: "wght" 600;
     min-height: var(--o-ui-sz-3);
     line-height: var(--o-ui-sz-3);
     width: max-content;
     height: max-content;
+}
+
+/* TEXT */
+.o-ui-lozenge-text {
+    text-transform: inherit;
 }
 
 /* HIGHLIGHT */

--- a/packages/components/src/lozenge/tests/chromatic/Lozenge.chroma.jsx
+++ b/packages/components/src/lozenge/tests/chromatic/Lozenge.chroma.jsx
@@ -155,6 +155,11 @@ stories()
             </Inline>
         </Stack>
     )
+    .add("inherit parent text properties", () =>
+        <Inline alignY="end">
+            <Lozenge textTransform="uppercase">New</Lozenge>
+        </Inline>
+    )
     .add("zoom", () =>
         <Inline>
             <Div className="zoom-in">


### PR DESCRIPTION
Issue: 

## Summary

Lozenge was the only component enforcing all caps on it's text, this did not feel right as in some cases long words were hard to read in all caps, all caps being harder to read. This PR aims at let the consumer capitalize words if needed either via a style prop or by typing in all caps.

## What I did

- Reworked the CSS to remove the text-transform
- Reworked the CSS to inherit a text-transform when set on the lozenge container.
- Upped the font-weight to help readability on lower end screens.

## How to test

/?path=/docs/chromatic-lozenge--default