### PR TITLE
Feature/964

### DIFF
--- a/docs/features/Slots.stories.mdx
+++ b/docs/features/Slots.stories.mdx
@@ -53,7 +53,7 @@ export const MyComponent = slot("name-of-the-slot-to-fulfill-by-default", () => 
 
 ## Explicit slots
 
-An explicit slot is defined by specifying the `slot` prop on a component declaration.
+> An explicit slot is defined by specifying the `slot` prop on a component declaration.
 
 ```jsx
 <Button variant="secondary">

--- a/docs/features/color-schemes/ColorSchemes.stories.mdx
+++ b/docs/features/color-schemes/ColorSchemes.stories.mdx
@@ -28,7 +28,7 @@ or be selected according to the [user's operating system setting](https://develo
 </ThemeProvider>
 ```
 
-When the `system` value is provided, an additional *fallback* color scheme must be provided to `defaultColorScheme` in case the theme provider is not able to access the user setting.
+> When the `system` value is provided, an additional *fallback* color scheme must be provided to `defaultColorScheme` in case the theme provider is not able to access the user setting.
 
 ## Changing the color scheme
 

--- a/docs/features/tokens/Tokens.stories.mdx
+++ b/docs/features/tokens/Tokens.stories.mdx
@@ -18,7 +18,7 @@ Aliased tokens are named for their use case, rather than their value. For exampl
 
 This makes their intended use clear and intentional, and allows us to develop a scalable and consistent visual language while also being the building block of Orbit's [theming](/docs/theming--page).
 
-In Orbit, **1 rem unit = 16 pixels**.
+> In Orbit, **1 rem unit = 16 pixels**.
 
 ## Usage
 

--- a/docs/getting-started/Installation.stories.mdx
+++ b/docs/getting-started/Installation.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta } from "@storybook/addon-docs";
 import { PackageInstallationSnippet } from "@stories/components";
+import { Message } from "@components/message";
 
 <Meta
     title="Installation"
@@ -10,7 +11,7 @@ import { PackageInstallationSnippet } from "@stories/components";
 
 Multiple [NPM packages](https://www.npmjs.com/settings/orbit-ui/packages) compose Orbit. By creating a bundle package named [@sharegate/orbit-ui](https://www.npmjs.com/package/@sharegate/orbit-ui), we simplify the installation process and allow you to install Orbit with just a single package.
 
-We assume that you have already set up [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom). Otherwise, **you'll get a warning at installation**.
+> We assume that you have already set up [react](https://www.npmjs.com/package/react) and [react-dom](https://www.npmjs.com/package/react-dom). Otherwise, <strong>you'll get a warning at installation</strong>.
 
 ### Install packages
 

--- a/packages/components/src/autocomplete/docs/Autocomplete.stories.mdx
+++ b/packages/components/src/autocomplete/docs/Autocomplete.stories.mdx
@@ -304,7 +304,7 @@ An autocomplete items can be fetch from a remote source.
 
 We provide an utility hook called `useAsyncSearch` which accept an *async* function responsible of fetching the data. You could roll your own utility hook as long as it returns a *loading indicator* and provide a function to handle *search* requests.
 
-In most cases, you should pass the [`signal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) arg to your `fetch` request.
+> In most cases, you should pass the [`signal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) arg to your `fetch` request.
 
 <Preview filePath="/autocomplete/docs/RemoteItems" scope={{ ApiKey: "8aa06f2e50msh9ff37516b3c0282p1e8624jsn81c867aa0d74" }} />
 

--- a/packages/components/src/date-input/docs/DateInput.stories.mdx
+++ b/packages/components/src/date-input/docs/DateInput.stories.mdx
@@ -19,7 +19,7 @@ import { subMonths, subWeeks } from "date-fns";
 
 ## Usage
 
-Please be aware that the [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date) constructor `monthIndex` argument is 0 based. Therefore, for `01/01/2021` you must write `new Date(2021, 0, 1)`.
+> Please be aware that the [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date) constructor `monthIndex` argument is 0 based. Therefore, for `01/01/2021` you must write `new Date(2021, 0, 1)`.
 
 ### Default
 

--- a/packages/components/src/form/docs/Form.stories.mdx
+++ b/packages/components/src/form/docs/Form.stories.mdx
@@ -31,7 +31,7 @@ import { PasswordInput, TextInput } from "@components/text-input";
 
 In additional to wrapping a form element, a form component provide layout for fields and buttons.
 
-To apply the layout correctly, every inputs must be wrapped in a field component.
+> To apply the layout correctly, every inputs must be wrapped in a field component.
 
 ### Vertical layout
 

--- a/packages/components/src/link/docs/Link.stories.mdx
+++ b/packages/components/src/link/docs/Link.stories.mdx
@@ -127,7 +127,7 @@ To integrate with a third-party routing library like [React Router](https://reac
 
 A link content can be a single icon.
 
-When using this variant, an accessible name must be provided through `aria-label` prop. See [WCAG practices](https://www.w3.org/TR/WCAG20-TECHS/ARIA6.html).
+> When using this variant, an accessible name must be provided through `aria-label` prop. See [WCAG practices](https://www.w3.org/TR/WCAG20-TECHS/ARIA6.html).
 
 <Preview>
     <Story name="icon link">

--- a/packages/components/src/menu/docs/Menu.stories.mdx
+++ b/packages/components/src/menu/docs/Menu.stories.mdx
@@ -312,7 +312,7 @@ A menu can display a validation state to communicate to the user whether the cur
 
 A menu supports multiple selection modes. By default, selection is disabled, however this can be changed by settings the `selectionMode` property to `"single"` or `"multiple"`.
 
-When using selection with a `<Menu>` component wraped inside a `<MenuTrigger>`, you must handled the selected keys in controlled mode with the `selectedKeys` property otherwise the selected keys won't be persisted through openings.
+> When using selection with a `<Menu>` component wraped inside a `<MenuTrigger>`, you must handled the selected keys in controlled mode with the `selectedKeys` property otherwise the selected keys won't be persisted through openings.
 
 <Preview filePath="/menu/docs/Selection" />
 

--- a/packages/components/src/modal/docs/Modal.stories.mdx
+++ b/packages/components/src/modal/docs/Modal.stories.mdx
@@ -236,7 +236,7 @@ By default, a modal will dismiss on outside interactions and `esc` keydown. Howe
 
 You can set the `dismissable` prop to `false` and render a call to action which will manually dismiss the popover by calling a `close` function retrieved from the `useModalTriggerContext` hook.
 
-Inlining the call to `useModalTriggerContext` in `ModalTrigger` will not work.
+> Inlining the call to `useModalTriggerContext` in `ModalTrigger` will not work.
 
 <Preview filePath="/modal/docs/ModalCustomClose" />
 

--- a/packages/components/src/styling/docs/theme-provider/ThemeProvider.stories.mdx
+++ b/packages/components/src/styling/docs/theme-provider/ThemeProvider.stories.mdx
@@ -20,7 +20,7 @@ import { ThemeProvider } from "@components/styling"
 
 Orbit components rely on the `ThemeProvider` to define the theme and color scheme they need to render accurately. We do recommended you declare a theme provider at the root of your application but if you prefer, you can declare them as needed instead.
 
-For more information, view the [theming](?path=/docs/theming--page) and [color schemes](?path=/docs/color-schemes--page) sections.
+> For more information, view the [theming](?path=/docs/theming--page) and [color schemes](?path=/docs/color-schemes--page) sections.
 
 ```jsx
 <ThemeProvider theme={ShareGateTheme} colorScheme="system" defaultColorScheme="light">

--- a/packages/components/src/tabs/docs/Tabs.stories.mdx
+++ b/packages/components/src/tabs/docs/Tabs.stories.mdx
@@ -134,7 +134,7 @@ Tabs items can be rendered dynamically.
 
 By default, tabs are activated automatically. This means when you use the arrow keys to change tabs, the tab is activated and focused.
 
-The content of a tab should ideally be preloaded. However, if switching to a tab panel causes a network request and possibly a page refresh, there might be some notable latency and this might affect the experience for keyboard and screen reader users.
+> The content of a tab should ideally be preloaded. However, if switching to a tab panel causes a network request and possibly a page refresh, there might be some notable latency and this might affect the experience for keyboard and screen reader users.
 
 In this scenario, you should use a manually activated tab, it moves focus without activating the tabs. With focus on a specifc tab, users can activate a tab by pressing ``Space`` or ``Enter``.
 

--- a/packages/components/src/transition/docs/Transition.stories.mdx
+++ b/packages/components/src/transition/docs/Transition.stories.mdx
@@ -18,7 +18,7 @@ import { InnerTransition } from "@components/transition";
 
 ## Usage
 
-This is a not a component to handle all kind of generic transitions. This component is specialized for *enter* and *leave* transitions.
+> This is a not a component to handle all kind of generic transitions. This component is specialized for *enter* and *leave* transitions.
 
 ### Example
 

--- a/packages/components/src/typography/docs/Text.stories.mdx
+++ b/packages/components/src/typography/docs/Text.stories.mdx
@@ -19,7 +19,7 @@ import { Stack } from "@components/layout";
 
 ## Usage
 
-Only use this component if all other Orbit typographic components doesn't meet your needs.
+> Only use this component if all other Orbit typographic components doesn't meet your needs.
 
 ### Size
 

--- a/packages/icons/docs/icons.stories.mdx
+++ b/packages/icons/docs/icons.stories.mdx
@@ -246,7 +246,7 @@ By default an icon component render as an `md` sized icon.
 
 To alter the dimensions of an icon, you can specify any of the following sizes: `"2xs"`, `"xs"`, `"sm"`, `"lg"`, `"xl"`, `"inherit"`.
 
-If your icon is intended to be used as content of an Orbit component, you won't have to specify the icon size since Orbit components already have pre-determined dimensions for their icons.
+> If your icon is intended to be used as content of an Orbit component, you won't have to specify the icon size since Orbit components already have pre-determined dimensions for their icons.
 
 <Preview>
     <CheckeredBackground>

--- a/storybook/mdx/highlight/Highlight.jsx
+++ b/storybook/mdx/highlight/Highlight.jsx
@@ -1,0 +1,12 @@
+import { Div } from "@components/html";
+import "./highlight.css";
+
+export function Highlight({ children, ...rest }) {
+    return (
+        <Div className="highlight"
+            {...rest}
+        >
+            {children}
+        </Div>
+    );
+}

--- a/storybook/mdx/highlight/highlight.css
+++ b/storybook/mdx/highlight/highlight.css
@@ -1,0 +1,12 @@
+.highlight {
+    background-color: var(--o-ui-bg-alias-accent-light);
+    padding: var(--o-ui-sp-3);
+    border-radius: var(--o-ui-br-rounded);
+}
+
+.highlight p {
+    padding: 0;
+    margin: 0;
+    padding-top: calc(var(--o-ui-sp-3) / 2);
+    padding-bottom: calc(var(--o-ui-sp-3) / 2);
+}

--- a/storybook/mdx/highlight/index.js
+++ b/storybook/mdx/highlight/index.js
@@ -1,0 +1,1 @@
+export * from "./Highlight";

--- a/storybook/mdx/index.js
+++ b/storybook/mdx/index.js
@@ -1,1 +1,2 @@
+export * from "./highlight";
 export * from "./code";

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -6,7 +6,7 @@ import { ShareGateTheme, createThemeVars } from "@components/styling";
 import { isChromatic, isDocs } from "./env";
 import { withBackgroundMatchingColorScheme, withCenteredCanvas, withDocsContainer, withThemeProvider } from "./decorators";
 
-import { Code } from "@stories/mdx";
+import { Code, Highlight } from "@stories/mdx";
 import { Themes } from "./styles/themes";
 
 createThemeVars([ShareGateTheme]);
@@ -48,6 +48,7 @@ export const parameters = {
         theme: Themes.docs,
         inlineStories: true,
         components: {
+            blockquote: Highlight,
             code: Code
         },
         container: ({ context, children }) => withDocsContainer(context, children),

--- a/storybook/styles/docs.css
+++ b/storybook/styles/docs.css
@@ -332,9 +332,11 @@
 
 /* ELEMENTS | BLOCKQUOTE */
 .sbdocs.sbdocs-blockquote {
-    padding: var(--o-ui-sp-3) var(--o-ui-sp-4) var(--o-ui-sp-3) var(--o-ui-sp-3);
-    background-color: var(--o-ui-purple-1);
+    background-color: var(--o-ui-bg-alias-accent-light);
+    padding: var(--o-ui-sp-3) var(--o-ui-sp-3) var(--o-ui-sp-3) var(--o-ui-sp-5);
+    border-radius: var(--o-ui-br-rounded);
     font-size: 15px !important;
+    border-left: none;
 }
 
 .sbdocs.sbdocs-blockquote p {

--- a/storybook/styles/docs.css
+++ b/storybook/styles/docs.css
@@ -330,19 +330,6 @@
     margin: var(--o-ui-sp-4) 0 !important;
 }
 
-/* ELEMENTS | BLOCKQUOTE */
-.sbdocs.sbdocs-blockquote {
-    background-color: var(--o-ui-bg-alias-accent-light);
-    padding: var(--o-ui-sp-3) var(--o-ui-sp-3) var(--o-ui-sp-3) var(--o-ui-sp-5);
-    border-radius: var(--o-ui-br-rounded);
-    font-size: 15px !important;
-    border-left: none;
-}
-
-.sbdocs.sbdocs-blockquote p {
-    font-size: 15px;
-}
-
 /* ELEMENTS | KBD */
 .sbdocs kbd {
     line-height: var(--o-ui-lh-1);


### PR DESCRIPTION
Issue: 

Fix for issue #964 

## Summary

Recovered documentation highlights that have been lost in an accessibility purge.

## What I did

Re-highlighted the important sections of the doc with markdown. The final result is a div instead of a blockquote since a blockquote was not the right intent.