### PR TITLE
removed related components from Modal doc as it was redundant

### DIFF
--- a/packages/components/src/modal/docs/Modal.stories.mdx
+++ b/packages/components/src/modal/docs/Modal.stories.mdx
@@ -255,12 +255,6 @@ You don't have to use a `ModalTrigger` component if it doesn't fit your needs. A
 
 <Preview filePath="/modal/docs/CustomTrigger" />
 
-## Related Components
-
-- To present a small supplemental amount of information in a non blocking way use a [Popover](?path=/docs/popover--default-story).
-- To communicate a change or condition that needs the user’s attention within the context of a page, use a [Message](?path=/docs/message--default-story).
-- To present large amounts of additional information or actions that don’t require confirmation, use an [Accordion](?path=/docs/accordion--default-story).
-
 ## API
 
 ### ModalTrigger


### PR DESCRIPTION
Issue: 

## Summary

With the dot restructure some content was still visible while now redundant. Modal still had a When to use section. 

## What I did

Removed the When to use section from the Modal doc.

