### PR TITLE
added guidelines title to Switch documentation

### DIFF
--- a/packages/components/src/switch/docs/Switch.stories.mdx
+++ b/packages/components/src/switch/docs/Switch.stories.mdx
@@ -21,6 +21,8 @@ import { Text } from "@components/typography";
     githubPath="/packages/components/src/switch/src"
 />
 
+## Guidelines
+
 ### When to use
 
 - To trigger an immediate action such as an activation/deactivation.


### PR DESCRIPTION
Issue: 

## Summary

Switch documentation was missing the Guidelines title.

## What I did

Added the missing the Guidelines title.