### PR TITLE
swapped aria links to the moved ones

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -290,7 +290,7 @@ Ex:
 
 #### Accessibility
 
-All components should follow [WAI-ARIA practices](https://www.w3.org/TR/wai-aria-practices/) when applicable.
+All components should follow [WAI-ARIA practices](https://www.w3.org/WAI/ARIA/apg/) when applicable.
 
 ## Babel
 

--- a/packages/components/src/accordion/docs/Accordion.stories.mdx
+++ b/packages/components/src/accordion/docs/Accordion.stories.mdx
@@ -17,7 +17,7 @@ import { InnerItem, Item } from "@components/collection";
 
 <ComponentInfo
     usage={"import { Accordion, Item, Header, Content, AccordionContext, useAccordionContext } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#accordion"
+    ariaPath="accordion"
     githubPath="/packages/components/src/accordion/src"
 />
 

--- a/packages/components/src/alert/docs/Alert.stories.mdx
+++ b/packages/components/src/alert/docs/Alert.stories.mdx
@@ -16,7 +16,7 @@ import { Heading, InnerHeading } from "@components/typography";
 
 <ComponentInfo
     usage={"import { Alert, Heading, Content, useAlertTriggerContext } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#alertdialog"
+    ariaPath="alertdialog"
     githubPath="/packages/components/src/alert/src"
 />
 

--- a/packages/components/src/autocomplete/docs/Autocomplete.stories.mdx
+++ b/packages/components/src/autocomplete/docs/Autocomplete.stories.mdx
@@ -17,7 +17,7 @@ import { Text } from "@components/typography";
 
 <ComponentInfo
     usage={"import { Autocomplete, Item, Section } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#combobox"
+    ariaPath="combobox"
     githubPath="/packages/components/src/autocomplete/src"
 />
 

--- a/packages/components/src/button/docs/Button.stories.mdx
+++ b/packages/components/src/button/docs/Button.stories.mdx
@@ -30,7 +30,7 @@ import { Text } from "@components/typography";
 
 <ComponentInfo
     usage={"import { Button, IconButton, ToggleButton, ToggleIconButton, ButtonGroup, ButtonAsLink } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#button"
+    ariaPath="button"
     githubPath="/packages/components/src/button/src"
 />
 

--- a/packages/components/src/button/docs/CrossButton.stories.mdx
+++ b/packages/components/src/button/docs/CrossButton.stories.mdx
@@ -14,7 +14,7 @@ import { Inline } from "@components/layout";
 
 <ComponentInfo
     usage="import { CrossButton } from @sharegate/orbit-ui"
-    ariaPath="#button"
+    ariaPath="button"
     githubPath="/packages/components/src/button/src"
 />
 

--- a/packages/components/src/checkbox/docs/Checkbox.stories.mdx
+++ b/packages/components/src/checkbox/docs/Checkbox.stories.mdx
@@ -17,7 +17,7 @@ import { Text } from "@components/typography";
 
 <ComponentInfo
     usage={"import { Checkbox, CheckboxGroup } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#checkbox"
+    ariaPath="checkbox"
     githubPath="/packages/components/src/checkbox/src"
 />
 

--- a/packages/components/src/disclosure/docs/Disclosure.stories.mdx
+++ b/packages/components/src/disclosure/docs/Disclosure.stories.mdx
@@ -17,7 +17,7 @@ import { Text } from "@components/typography";
 
 <ComponentInfo
     usage={"import { Disclosure, Content, DisclosureContext, useDisclosureContext } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#disclosure"
+    ariaPath="disclosure"
     githubPath="/packages/components/src/disclosure/src"
 />
 

--- a/packages/components/src/link/docs/Link.stories.mdx
+++ b/packages/components/src/link/docs/Link.stories.mdx
@@ -19,7 +19,7 @@ import { Text } from "@components/typography";
 
 <ComponentInfo
     usage={"import { TextLink, IconLink, Link, TextLinkAsButton, IconLinkAsButton } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#link"
+    ariaPath="link"
     githubPath="/packages/components/src/link/src"
 />
 

--- a/packages/components/src/listbox/docs/Listbox.stories.mdx
+++ b/packages/components/src/listbox/docs/Listbox.stories.mdx
@@ -19,7 +19,7 @@ import { Tooltip, TooltipTrigger } from "@components/tooltip";
 
 <ComponentInfo
     usage={"import { Listbox, Item, Section, ListboxContext, useListboxContext } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#listbox"
+    ariaPath="listbox"
     githubPath="/packages/components/src/listbox/src"
 />
 

--- a/packages/components/src/menu/docs/Menu.stories.mdx
+++ b/packages/components/src/menu/docs/Menu.stories.mdx
@@ -21,7 +21,7 @@ import { Tooltip, TooltipTrigger } from "@components/tooltip";
 
 <ComponentInfo
     usage={"import { MenuTrigger, Menu, Item, Section, Divider, MenuTriggerContext, useMenuTriggerContext } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#menu"
+    ariaPath="menu"
     githubPath="/packages/components/src/menu/src"
 />
 

--- a/packages/components/src/message/docs/Message.stories.mdx
+++ b/packages/components/src/message/docs/Message.stories.mdx
@@ -17,7 +17,7 @@ import { TextLink } from "@components/link";
 
 <ComponentInfo
     usage={"import { Message, Content } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#alert"
+    ariaPath="alert"
     githubPath="/packages/components/src/message/src"
 />
 

--- a/packages/components/src/modal/docs/Modal.stories.mdx
+++ b/packages/components/src/modal/docs/Modal.stories.mdx
@@ -22,7 +22,7 @@ import { TextLink } from "@components/link";
 
 <ComponentInfo
     usage={"import { Modal, ModalTrigger, Heading, Header, Content, Footer, ModalTriggerContext, useModalTriggerContext } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#dialog_modal"
+    ariaPath="dialogmodal"
     githubPath="/packages/components/src/modal/src"
 />
 

--- a/packages/components/src/radio/docs/Radio.stories.mdx
+++ b/packages/components/src/radio/docs/Radio.stories.mdx
@@ -16,7 +16,7 @@ import { Text } from "@components/typography";
 
 <ComponentInfo
     usage={"import { RadioGroup, Radio } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#radiobutton"
+    ariaPath="radiobutton"
     githubPath="/packages/components/src/radio/src"
 />
 

--- a/packages/components/src/select/docs/Select.stories.mdx
+++ b/packages/components/src/select/docs/Select.stories.mdx
@@ -18,7 +18,7 @@ import { Tooltip, TooltipTrigger } from "@components/tooltip";
 
 <ComponentInfo
     usage={"import { Select, Item, Section, HiddenSelect, useSelect } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#listbox"
+    ariaPath="listbox"
     githubPath="/packages/components/src/select/src"
 />
 

--- a/packages/components/src/switch/docs/Switch.stories.mdx
+++ b/packages/components/src/switch/docs/Switch.stories.mdx
@@ -17,7 +17,7 @@ import { Text } from "@components/typography";
 
 <ComponentInfo
     usage={"import { Switch } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#checkbox"
+    ariaPath="checkbox"
     githubPath="/packages/components/src/switch/src"
 />
 

--- a/packages/components/src/tabs/docs/Tabs.stories.mdx
+++ b/packages/components/src/tabs/docs/Tabs.stories.mdx
@@ -19,7 +19,7 @@ import { Text } from "@components/typography";
 
 <ComponentInfo
     usage={"import { Tabs, Item, Header, Content, TabsContext, useTabsContext } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#tabpanel"
+    ariaPath="tabpanel"
     githubPath="/packages/components/src/tabs/src"
 />
 

--- a/packages/components/src/toolbar/docs/Toolbar.stories.mdx
+++ b/packages/components/src/toolbar/docs/Toolbar.stories.mdx
@@ -18,7 +18,7 @@ import { ToggleButton } from "@components/button";
 
 <ComponentInfo
     usage={"import { Toolbar, ToolbarContext, useToolbarContext, useToolbarProps, ClearToolbar } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#toolbar"
+    ariaPath="toolbar"
     githubPath="/packages/components/src/toolbar/src"
 />
 

--- a/packages/components/src/tooltip/docs/Tooltip.stories.mdx
+++ b/packages/components/src/tooltip/docs/Tooltip.stories.mdx
@@ -16,7 +16,7 @@ import { InnerTooltip, InnerTooltipTrigger, Tooltip, TooltipTrigger } from "@com
 
 <ComponentInfo
     usage={"import { TooltipTrigger, Tooltip, useTooltipTriggerContext } from \"@sharegate/orbit-ui\";"}
-    ariaPath="#tooltip"
+    ariaPath="tooltip"
     githubPath="/packages/components/src/tooltip/src"
 />
 

--- a/storybook/components/component-info/ComponentInfo.jsx
+++ b/storybook/components/component-info/ComponentInfo.jsx
@@ -82,7 +82,7 @@ export function ComponentInfo({
                 <Div className="o-ui-sb-component-info-item">
                     <dt className="o-ui-sb-component-info-title">wai-aria</dt>
                     <dd className="o-ui-sb-component-info-value">
-                        <ExternalLink href={`https://www.w3.org/TR/wai-aria-practices/${ariaPath}`}>{`https://www.w3.org/TR/wai-aria-practices/${ariaPath}`}</ExternalLink>
+                        <ExternalLink href={`https://www.w3.org/WAI/ARIA/apg/patterns/${ariaPath}`}>{`https://www.w3.org/WAI/ARIA/apg/patterns/${ariaPath}`}</ExternalLink>
                     </dd>
                 </Div>
             )}


### PR DESCRIPTION
Issue: 

## Summary

WAI-ARIA Authoring Practices have been moved. This was impacting our doc as we link to some of their pages.

## What I did

Replaced the URLs in our mdx files.

## How to test

Click on the different wai-aria links in our components documentation.