### PR TITLE
Feature/905

### DIFF
--- a/packages/components/src/tile/src/Tile.css
+++ b/packages/components/src/tile/src/Tile.css
@@ -86,10 +86,6 @@
     mask-image: url("~@orbit-ui/icons/dist/icon-check-circle-24.svg");
 }
 
-.o-ui-tile-checkable:hover:not([disabled]):not([aria-checked="true"]):not([aria-pressed="true"])::before {
-    opacity: 0.7;
-}
-
 .o-ui-tile[aria-checked="true"]::before,
 .o-ui-tile[aria-pressed="true"]::before {
     opacity: 1;


### PR DESCRIPTION
Issue: 

## Summary

#905 - A tile hover style is too similar to the "checked" state

A tile hover style is too similar to the "checked" state. Therefore, "unchecking" a Tile doesn't seem to work until you mouse out of the Tile.

## What I did

Removed the CSS responsible of making the checkmark appear on hover.

## How to test

?path=/docs/tile--tile