### PR TITLE
aligned text to avatar

### DIFF
--- a/packages/components/src/avatar/src/Avatar.css
+++ b/packages/components/src/avatar/src/Avatar.css
@@ -82,6 +82,11 @@
     list-style-type: none;
 }
 
+.o-ui-avatar-group-remainings-list-item {
+    display: flex;
+    align-items: center;
+}
+
 .o-ui-avatar-group-remainings-list-item:not(:last-child) {
     margin-bottom: var(--o-ui-sp-2);
 }


### PR DESCRIPTION
Issue: 

## Summary

https://github.com/gsoft-inc/sg-orbit/issues/990

When a remaining Avatar had an image the name was misaligned.

## What I did

Remaining list is now using flex and aligns items vertically.

## How to test

?path=/docs/avatar--default-story

Create an AvatarGroup like the following, see that the on over bubble shows different alignments :

```
<AvatarGroup>
    <Avatar name="Sally Ride" />
    <Avatar name="Alan Shepard" />
    <Avatar src={ChrisHadfield} name="Chris Hadfield" />
    <Avatar name="1234" />
    <Avatar src={ChrisHadfield} name="adfasdf" />
    <Avatar name="AAAAA CCCCCC" />
    <Avatar src={ChrisHadfield} name="asdfasdfasdfasdf" />
</AvatarGroup>
```