### PR TITLE
fix reconciliate error who removed avatar css fix

### DIFF
--- a/packages/components/src/avatar/src/Avatar.css
+++ b/packages/components/src/avatar/src/Avatar.css
@@ -82,6 +82,11 @@
     list-style-type: none;
 }
 
+.o-ui-avatar-group-remainings-list-item {
+    display: flex;
+    align-items: center;
+}
+
 .o-ui-avatar-group-remainings-list-item:not(:last-child) {
     margin-bottom: var(--o-ui-sp-2);
 }


### PR DESCRIPTION
Issue: 

## Summary

While removing the avatar fix to branch feature/993 as it was not meant to be there, merging it into master removed the avatar css fixes. This PR aims at bringing the css fixes back to master.

## What I did

Added the CSS that was done in https://github.com/gsoft-inc/sg-orbit/pull/991 and lost in a reconciliation.