### PR TITLE
removed user agent margin on inputs

### DIFF
--- a/packages/components/src/input/src/Input.css
+++ b/packages/components/src/input/src/Input.css
@@ -25,6 +25,7 @@
     background-color: inherit;
     color: inherit;
     min-height: calc(var(--o-ui-sz-6) - 2px);
+    margin: 0;
     padding: 0;
 }
 


### PR DESCRIPTION
Issue: 

## Summary

Inputs margins were not reset, causing issues in Safari.

## What I did

Removed the margin on orbit's inputs as some browsers, Safari, were adding a 2px margin on top and bottom of all inputs.

## How to test

using Safari open ?path=/docs/date-input--default-story#presets