### PR TITLE
Feature/976

### DIFF
--- a/packages/components/src/lozenge/docs/Lozenge.stories.mdx
+++ b/packages/components/src/lozenge/docs/Lozenge.stories.mdx
@@ -19,7 +19,6 @@ import { Text } from "@components/typography";
     githubPath="/packages/components/src/lozenge/src"
 />
 
-
 ## Guidelines
 
 ### When to use

--- a/packages/components/src/lozenge/src/Lozenge.css
+++ b/packages/components/src/lozenge/src/Lozenge.css
@@ -54,7 +54,7 @@
 }
 
 .o-ui-lozenge.o-ui-lozenge-informative.o-ui-lozenge-highlight .o-ui-lozenge-text {
-    color: var(--o-ui-white);
+    color: inherit;
 }
 
 .o-ui-lozenge.o-ui-lozenge-informative.o-ui-lozenge-highlight .o-ui-lozenge-icon {
@@ -74,7 +74,7 @@
 }
 
 .o-ui-lozenge.o-ui-lozenge-positive.o-ui-lozenge-highlight .o-ui-lozenge-text {
-    color: var(--o-ui-white);
+    color: inherit;
 }
 
 .o-ui-lozenge.o-ui-lozenge-positive.o-ui-lozenge-highlight .o-ui-lozenge-icon {

--- a/packages/components/src/lozenge/src/Lozenge.css
+++ b/packages/components/src/lozenge/src/Lozenge.css
@@ -53,15 +53,6 @@
     color: var(--o-ui-white);
 }
 
-.o-ui-lozenge.o-ui-lozenge-informative.o-ui-lozenge-highlight .o-ui-lozenge-text {
-    color: inherit;
-}
-
-.o-ui-lozenge.o-ui-lozenge-informative.o-ui-lozenge-highlight .o-ui-lozenge-icon {
-    fill: currentColor;
-    color: inherit;
-}
-
 /* SUCCESS */
 .o-ui-lozenge.o-ui-lozenge-positive {
     background-color: var(--o-ui-bg-alias-success-light);

--- a/packages/components/src/lozenge/src/Lozenge.tsx
+++ b/packages/components/src/lozenge/src/Lozenge.tsx
@@ -19,7 +19,7 @@ import { embeddedIconSize } from "../../icons";
 
 const DefaultElement = "span";
 
-export interface InnerLozengeProps extends SlotProps, InternalProps, Omit<StyledComponentProps<typeof DefaultElement>, "color" | "backgroundColor"> {
+export interface InnerLozengeProps extends SlotProps, InternalProps {
     /**
      * React children.
      */

--- a/packages/components/src/lozenge/src/Lozenge.tsx
+++ b/packages/components/src/lozenge/src/Lozenge.tsx
@@ -19,7 +19,7 @@ import { embeddedIconSize } from "../../icons";
 
 const DefaultElement = "span";
 
-export interface InnerLozengeProps extends SlotProps, InternalProps {
+export interface InnerLozengeProps extends SlotProps, InternalProps, StyledComponentProps<typeof DefaultElement> {
     /**
      * React children.
      */

--- a/packages/components/src/lozenge/tests/chromatic/Lozenge.chroma.jsx
+++ b/packages/components/src/lozenge/tests/chromatic/Lozenge.chroma.jsx
@@ -158,6 +158,7 @@ stories()
     .add("inherit parent text properties", () =>
         <Inline alignY="end">
             <Lozenge textTransform="uppercase">New</Lozenge>
+            <Lozenge color="red" highlight>New</Lozenge>
         </Inline>
     )
     .add("zoom", () =>

--- a/packages/components/src/lozenge/tests/chromatic/Lozenge.chroma.jsx
+++ b/packages/components/src/lozenge/tests/chromatic/Lozenge.chroma.jsx
@@ -155,10 +155,13 @@ stories()
             </Inline>
         </Stack>
     )
-    .add("inherit parent text properties", () =>
+    .add("inherit parent properties", () =>
         <Inline alignY="end">
             <Lozenge textTransform="uppercase">New</Lozenge>
-            <Lozenge color="red" highlight>New</Lozenge>
+            <Lozenge color="red" highlight>
+                <CheckCircleIcon />
+                <Text>New</Text>
+            </Lozenge>
         </Inline>
     )
     .add("zoom", () =>


### PR DESCRIPTION
Issue: 

## Summary

Trying to override a Lozenge color and backgroundColor was throwing a typescript error as well as not working in some situations (when a lozenge had the highlight prop).

## What I did

Removed the typescript omissions in the component declaration. Modified the CSS of lozenge to work when highlighted.

## How to test

/?path=/story/chromatic-lozenge--inherit-parent-text-properties and by adding a color and backgroundColor prop to a lozenge