### PR TITLE
removed unnecessary z index on checkbox box / removed z index on unde…

### DIFF
--- a/packages/components/src/checkbox/src/Checkbox.css
+++ b/packages/components/src/checkbox/src/Checkbox.css
@@ -26,7 +26,6 @@
     border-radius: var(--o-ui-br-rounded);
     transition: all var(--o-ui-easing-duration-2) var(--o-ui-easing-productive);
     flex-shrink: 0;
-    z-index: 2;
 }
 
 /* STATES | FOCUS | FOCUS RING */

--- a/packages/components/src/overlay/src/Underlay.css
+++ b/packages/components/src/overlay/src/Underlay.css
@@ -4,7 +4,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 1;
+    isolation: isolate;
     background-color: rgba(0, 0, 0, 0.6);
     overflow: hidden;
 }


### PR DESCRIPTION
Issue: 

## Summary

Checkbox was showing over underlays due to a z-index issue.

## What I did

- removed the z-index on the checkbox box as it was unnecessary
- removed the z-index on the underlay and used isolation isolate (as suggested here https://sherryhsu.medium.com/how-to-avoid-z-index-war-9d22b44ca61a and here https://www.joshwcomeau.com/css/stacking-contexts)

## How to test

add a checkbox next to an Alert, it's not over anymore.