### PR TITLE
small lozenge text should be uppercase when small / adjusted the doc …

### DIFF
--- a/packages/components/src/lozenge/docs/Lozenge.stories.mdx
+++ b/packages/components/src/lozenge/docs/Lozenge.stories.mdx
@@ -64,13 +64,13 @@ An [icon](?path=/docs/icon-gallery--page) is used to make it easier for the user
 
 ### Size
 
-The lozenge can be used in small version to accommodate smaller spaces, such as a column row. When used in small format, the lozenge should not contain an icon.
+The lozenge can be used in small version to accommodate smaller spaces, such as a column row. When used in small format, the lozenge should not contain an icon, and text is automatically set to uppercase.
 
 <Preview>
     <Story name="size">
         <Inline alignY="center">
-            <Lozenge size="sm">NEW</Lozenge>
-            <Lozenge>NEW</Lozenge>
+            <Lozenge size="sm">New</Lozenge>
+            <Lozenge>New release</Lozenge>
         </Inline>
     </Story>
 </Preview>

--- a/packages/components/src/lozenge/src/Lozenge.tsx
+++ b/packages/components/src/lozenge/src/Lozenge.tsx
@@ -45,6 +45,10 @@ const textSize = createSizeAdapter({
 });
 /* eslint-enable sort-keys, sort-keys-fix/sort-keys-fix */
 
+const textTransform = function (size) {
+    return size === "sm" ? "uppercase" : null;
+};
+
 export function InnerLozenge({
     as = DefaultElement,
     children,
@@ -68,7 +72,8 @@ export function InnerLozenge({
         },
         text: {
             className: "o-ui-lozenge-text",
-            size: textSize(sizeValue)
+            size: textSize(sizeValue),
+            textTransform: textTransform(sizeValue)
         }
     }), [sizeValue]));
 


### PR DESCRIPTION
…and the component

Issue: 

#979 - Small Lozenge should not use lowercase text as it's hard to read.

## Summary

A small Lozenge should not use lowercase text as it makes it hard to read for the users. We now enforce an uppercase on small lozenge text.

## What I did

When lozenge component size is small we set the textTransform property to `uppercase` by default.
