### PR TITLE
offloaded text transform to CSS

### DIFF
--- a/packages/components/src/lozenge/src/Lozenge.css
+++ b/packages/components/src/lozenge/src/Lozenge.css
@@ -28,6 +28,10 @@
     line-height: var(--o-ui-sz-2);
 }
 
+.o-ui-lozenge-sm .o-ui-lozenge-text {
+    text-transform: uppercase;
+}
+
 .o-ui-lozenge-lg {
     min-height: var(--o-ui-sz-4);
     line-height: var(--o-ui-sz-4);

--- a/packages/components/src/lozenge/src/Lozenge.tsx
+++ b/packages/components/src/lozenge/src/Lozenge.tsx
@@ -45,10 +45,6 @@ const textSize = createSizeAdapter({
 });
 /* eslint-enable sort-keys, sort-keys-fix/sort-keys-fix */
 
-const textTransform = function (size) {
-    return size === "sm" ? "uppercase" : null;
-};
-
 export function InnerLozenge({
     as = DefaultElement,
     children,
@@ -72,8 +68,7 @@ export function InnerLozenge({
         },
         text: {
             className: "o-ui-lozenge-text",
-            size: textSize(sizeValue),
-            textTransform: textTransform(sizeValue)
+            size: textSize(sizeValue)
         }
     }), [sizeValue]));
 


### PR DESCRIPTION
Issue: 

#979 - Small Lozenge should not use lowercase text as it's hard to read.

## Summary

A small Lozenge should not use lowercase text as it makes it hard to read for the users. We now enforce an uppercase on small lozenge text.

## What I did

When lozenge component size is small we set the textTransform property to `uppercase` by default.
