### PR TITLE
Make item children optional

### DIFF
--- a/packages/components/src/collection/src/Item.tsx
+++ b/packages/components/src/collection/src/Item.tsx
@@ -5,7 +5,7 @@ export interface InnerItemProps extends InternalProps, StyledHtmlAttributes {
     /**
      * React children.
      */
-    children: ReactNode;
+    children?: ReactNode;
     /**
      * A unique key to identify the item.
      */
@@ -23,3 +23,5 @@ export const Item = forwardRef<any, OmitInternalProps<InnerItemProps>>((props, r
 ));
 
 export type ItemProps = ComponentProps<typeof Item>;
+
+const foo = <Item />;


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Issue: 

There might be some cases where in the future where the `<Item />` component might be used with optional children. 

However, it is currently impossible to use the `<Item />` component in TypeScript without having explicit children, or without doing `<Item children={undefined} />` (this works since `undefined` is a valid `ReactNode`)

## What I did

I made Item's `children` prop optional.

<!-- fill this out -->

## How to test

No need, since it's only a small change to TypeScript's type definition and the type checking of Orbit seemed fine with the changes.
