### PR TITLE
textarea now inherit input color

### DIFF
--- a/packages/components/src/text-area/src/TextArea.css
+++ b/packages/components/src/text-area/src/TextArea.css
@@ -5,6 +5,7 @@
     overflow-x: hidden;
     padding: var(--o-ui-sp-2) var(--o-ui-textarea-padding);
     min-height: var(--o-ui-sz-11);
+    color: inherit;
 }
 
 /* TRANSPARENT */


### PR DESCRIPTION
Issue: 

## Summary

#1019 - TextArea's text doesn't have the right color in dark mode

## What I did

Textarea now inherits the input text color, since the hiearchy is different from the text input where an input has it's style directly applied, a textarea has a wrapper.