### PR TITLE
split transform properties in their single counterparts

### DIFF
--- a/docs/materials/motion/Motion.stories.mdx
+++ b/docs/materials/motion/Motion.stories.mdx
@@ -29,11 +29,11 @@ In animation declaration :
 @keyframes tease-animation  {
     0% {
         opacity: 0;
-        transform: scale(1.2);
+        scale: 1.2;
     }
     100% {
         opacity: 1;
-        transform: scale(1);
+        scale: 1;
     }
 }
 

--- a/docs/materials/motion/MotionPreview.css
+++ b/docs/materials/motion/MotionPreview.css
@@ -9,9 +9,9 @@
     background-color: #6B5B7B;
     width: 10rem;
     height: 10rem;
-    transition: transform var(--o-ui-sb-duration) var(--o-ui-sb-easing);
+    transition: translate var(--o-ui-sb-duration) var(--o-ui-sb-easing);
 }
 
 .o-ui-sb-object-animated {
-    transform: translateX(100px);
+    translate: 100px;
 }

--- a/packages/components/src/badge/src/Badge.css
+++ b/packages/components/src/badge/src/Badge.css
@@ -9,7 +9,8 @@
     position: absolute;
     top: 0;
     right: 0;
-    transform: scale(1) translate(50%, -50%);
+    scale: 1;
+    translate: 50% -50%;
     transform-origin: 100% 0%;
 }
 

--- a/packages/components/src/button/src/Button.css
+++ b/packages/components/src/button/src/Button.css
@@ -218,7 +218,7 @@ a.o-ui-button {
     border: 2px solid var(--o-ui-b-alias-low-break);
     border-top-color: var(--o-ui-b-alias-high-break);
     animation: o-ui-button-spinner 1s linear infinite;
-    transform: rotate(0deg);
+    rotate: 0deg;
     position: absolute;
     left: 0;
     right: 0;
@@ -242,10 +242,10 @@ a.o-ui-button {
 
 @keyframes o-ui-button-spinner {
     0% {
-        transform: rotate(0deg);
+        rotate: 0deg;
     }
     100% {
-        transform: rotate(360deg);
+        rotate: 360deg;
     }
 }
 

--- a/packages/components/src/checkbox/src/Checkbox.css
+++ b/packages/components/src/checkbox/src/Checkbox.css
@@ -53,32 +53,37 @@
     mask: url("~@orbit-ui/icons/dist/icon-check-24.svg") center center no-repeat;
     mask-size: var(--o-ui-sz-3) var(--o-ui-sz-3);
     background-color: var(--o-ui-white);
-    transform: translate(-50%, -50%) scale(0) rotate(2deg);
+    translate: -50% -50%;
+    scale: 0;
+    rotate: 2deg;
     transition: all var(--o-ui-easing-duration-1) var(--o-ui-easing-productive);
     border-radius: var(--o-ui-br-rounded);
 }
 
 .o-ui-checkbox-checked .o-ui-checkbox-box:after {
     mask: url("~@orbit-ui/icons/dist/icon-check-24.svg") center center no-repeat;
-    transform: translate(-50%, -50%) scale(1) rotate(2deg);
+    scale: 1;
+    rotate: 2deg;
 }
 
 /* CHECKED | SMALL */
 .o-ui-checkbox-sm.o-ui-checkbox-checked .o-ui-checkbox-box:after {
     mask: url("~@orbit-ui/icons/dist/icon-check-24.svg") center center no-repeat;
-    transform: translate(-50%, -50%) scale(0.75) rotate(2deg);
+    scale: 0.75;
+    rotate: 2deg;
 }
 
 /* BOX | INDETERMINATE */
 .o-ui-checkbox-indeterminate .o-ui-checkbox-box:after {
-    transform: translate(-50%, -50%) scale(0.33) rotate(2deg);
+    scale: 0.33;
+    rotate: 2deg;
     mask: none;
     background-color: var(--o-ui-bg-alias-accent);
 }
 
 /* not working since intedermenate class is removed as soon as it's clicked */
 .o-ui-checkbox-indeterminate .o-ui-checkbox-box::after {
-    transition: transform var(--o-ui-easing-duration-2) var(--o-ui-easing-focus) 0.0625s;
+    transition: scale var(--o-ui-easing-duration-2) var(--o-ui-easing-focus) 0.0625s;
 }
 
 /* BOX | INDETERMINATE | STATE | INVALID */
@@ -143,7 +148,7 @@
 
 /* STATE | CHECKED | CHECKMARK */
 .o-ui-checkbox-checked .o-ui-checkbox-box:before {
-    transform: scale(1);
+    scale: 1;
 }
 
 /* STATE | DISABLED */

--- a/packages/components/src/disclosure/src/DisclosureArrow.css
+++ b/packages/components/src/disclosure/src/DisclosureArrow.css
@@ -5,9 +5,9 @@
 }
 
 .o-ui-disclosure-arrow-up {
-    transform: rotate(-90deg);
+    rotate: -90deg;
 }
 
 .o-ui-disclosure-arrow-down {
-    transform: rotate(90deg);
+    rotate: 90deg;
 }

--- a/packages/components/src/input/src/Input.css
+++ b/packages/components/src/input/src/Input.css
@@ -200,10 +200,10 @@
 /* STATES | LOADING */
 @keyframes o-ui-input-spinner {
     0% {
-        transform: translate(0, -50%) rotate(0deg);
+        rotate: 0deg;
     }
     100% {
-        transform: translate(0, -50%) rotate(360deg);
+        rotate: 360deg;
     }
 }
 
@@ -215,7 +215,8 @@
     border-radius: 50px;
     border: 2px solid var(--o-ui-b-alias-low-break);
     border-top-color: var(--o-ui-b-alias-mid-break);
-    transform: translate(0, -50%) rotate(0deg);
+    translate: 0 -50%;
+    rotate: 0deg;
     animation: o-ui-input-spinner 1s linear infinite;
     width: 1.25rem;
     height: 1.25rem;

--- a/packages/components/src/overlay/src/Overlay.css
+++ b/packages/components/src/overlay/src/Overlay.css
@@ -24,7 +24,7 @@
 
 .o-ui-overlay-arrow::before {
     content: "";
-    transform: rotate(45deg);
+    rotate: 45deg;
     background-color: var(--o-ui-bg-alias-default);
     box-shadow: var(--o-ui-bs-alias-raised);
 }

--- a/packages/components/src/radio/src/Radio.css
+++ b/packages/components/src/radio/src/Radio.css
@@ -26,7 +26,7 @@
     display: block;
     background-color: var(--o-ui-bg-alias-accent);
     border-radius: var(--o-ui-br-circular);
-    transform: scale(0);
+    scale: 0;
     transition: all var(--o-ui-easing-duration-1) var(--o-ui-easing-productive);
     position: absolute;
     top: 50%;
@@ -95,7 +95,7 @@
 
 /* STATE | CHECKED */
 .o-ui-radio-checked .o-ui-radio-button::before {
-    transform: scale(0.5);
+    scale: 0.5;
 }
 
 .o-ui-radio-checked.o-ui-radio-invalid .o-ui-radio-button {

--- a/packages/components/src/switch/src/Switch.css
+++ b/packages/components/src/switch/src/Switch.css
@@ -25,7 +25,7 @@
     background-color: var(--o-ui-bg-alias-static-white);
     border-radius: var(--o-ui-br-circular);
     position: absolute;
-    transform: translate(2px, 2px);
+    translate: 2px 2px;
     transition: all var(--o-ui-easing-duration-2) var(--o-ui-easing-focus);
 }
 
@@ -81,7 +81,7 @@
 }
 
 .o-ui-switch-checked .o-ui-switch-control::before {
-    transform: translate(calc(var(--o-ui-sz-6) / 2 + 2px), 2px);
+    translate: calc(var(--o-ui-sz-6) / 2 + 2px) 2px;
 }
 
 /* STATE | FOCUS */
@@ -124,7 +124,7 @@
 }
 
 .o-ui-switch-sm.o-ui-switch-checked .o-ui-switch-control::before {
-    transform: translate(calc(var(--o-ui-sz-5) / 2 + 2px), 2px);
+    translate: calc(var(--o-ui-sz-5) / 2 + 2px) 2px;
 }
 
 /* MEDIUM */
@@ -140,5 +140,5 @@
 }
 
 .o-ui-switch-md.o-ui-switch-checked .o-ui-switch-control::before {
-    transform: translate(calc(var(--o-ui-sz-6) / 2 + 2px), 2px);
+    translate: calc(var(--o-ui-sz-6) / 2 + 2px) 2px;
 }

--- a/packages/components/src/tabs/src/Tabs.css
+++ b/packages/components/src/tabs/src/Tabs.css
@@ -126,7 +126,7 @@
     content: "";
     position: absolute;
     top: 50%;
-    transform: translateY(-50%);
+    translate: 0 -50%;
     bottom: calc(0.5rem - 2px);
     border: var(--o-ui-focus-ring-thickness-md) transparent solid;
     border-radius: var(--o-ui-br-rounded);

--- a/packages/components/src/text-area/src/TextArea.css
+++ b/packages/components/src/text-area/src/TextArea.css
@@ -17,7 +17,7 @@
 .o-ui-text-area .o-ui-input-button {
     position: absolute !important;
     top: 50%;
-    transform: translateY(-50%);
+    translate: 0 -50%;
     justify-content: center;
     align-items: center;
     text-align: center;

--- a/storybook/components/preview/Preview.css
+++ b/storybook/components/preview/Preview.css
@@ -20,7 +20,7 @@
     position: absolute;
     top: 3px;
     left: 50%;
-    transform: translateX(-50%);
+    translate: -50%;
     color: var(--o-ui-white);
     z-index: 1;
     font-size: 0.625rem;

--- a/storybook/styles/docs.css
+++ b/storybook/styles/docs.css
@@ -393,15 +393,17 @@
     border: 2px solid var(--o-ui-b-alias-low-break);
     border-top-color: var(--o-ui-white);
     animation: o-ui-sb-spinner 1s linear infinite;
-    transform: translate(-50%, -50%) rotate(0deg);
+    translate: -50% -50%;
+    /* might be possible to remove to validate */
+    rotate: 0deg;
 }
 
 @keyframes o-ui-sb-spinner {
     0% {
-        transform: translate(-50%, -50%) rotate(0deg);
+        rotate: 0deg;
     }
     100% {
-        transform: translate(-50%, -50%) rotate(360deg);
+        rotate: 360deg;
     }
 }
 


### PR DESCRIPTION
Issue: 

## Summary

Fixed issue https://github.com/gsoft-inc/sg-orbit/issues/1022.

Used the rotate, scale and translate individually to render our CSS more concise and easier to understand.

## What I did

Removed transform shorthand declarations in order to use their counterparts