### PR TITLE
Fix dark mode, using Globals

### DIFF
--- a/storybook/decorators/withBackgroundMatchingColorScheme.jsx
+++ b/storybook/decorators/withBackgroundMatchingColorScheme.jsx
@@ -1,6 +1,8 @@
 import { isNil } from "@components/shared";
 import { useEffect } from "react";
 
+import { useGlobals } from "./withDocsContainer";
+
 const StyleElementId = "story-background-color";
 
 const BackgroundColors = {
@@ -9,7 +11,8 @@ const BackgroundColors = {
 };
 
 export function withBackgroundMatchingColorScheme(story, context) {
-    const colorScheme = context.globals.colorScheme;
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { colorScheme } = useGlobals();
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {

--- a/storybook/decorators/withBackgroundMatchingColorScheme.jsx
+++ b/storybook/decorators/withBackgroundMatchingColorScheme.jsx
@@ -1,7 +1,7 @@
 import { isNil } from "@components/shared";
 import { useEffect } from "react";
 
-import { useGlobals } from "./withDocsContainer";
+import { getGlobals } from "../utils";
 
 const StyleElementId = "story-background-color";
 
@@ -11,8 +11,7 @@ const BackgroundColors = {
 };
 
 export function withBackgroundMatchingColorScheme(story, context) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const { colorScheme } = useGlobals();
+    const { colorScheme } = getGlobals(context);
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {

--- a/storybook/decorators/withDocsContainer.jsx
+++ b/storybook/decorators/withDocsContainer.jsx
@@ -1,13 +1,5 @@
 import { DocsContainer } from "@storybook/addon-docs";
 import { ShareGateTheme, ThemeProvider } from "@components/styling";
-import { createContext } from "react";
-import { useContext } from "react";
-
-const GlobalsContext = createContext();
-
-function GlobalsProvider({ globals, children }) {
-    return <GlobalsContext.Provider value={globals}>{children}</GlobalsContext.Provider>;
-}
 
 function ThemedDocsContainer({ context, children }) {
     const theme = context.globals.theme === "sharegate" ? ShareGateTheme : ShareGateTheme;
@@ -20,21 +12,11 @@ function ThemedDocsContainer({ context, children }) {
 }
 
 export function withDocsContainer(context, children) {
-    // The following line might not work on storybook@7.0.0
-    // If it still works, remove this comment.
-    // See https://github.com/storybookjs/storybook/issues/18477#issuecomment-1198852168
-    const story = context.storyById(context.id);
-    const { globals } = context.getStoryContext(story);
-
     return (
         <DocsContainer context={context}>
             <ThemedDocsContainer context={context}>
-                <GlobalsProvider globals={globals}>
-                    {children}
-                </GlobalsProvider>
+                {children}
             </ThemedDocsContainer>
         </DocsContainer>
     );
 }
-
-export const useGlobals = () => useContext(GlobalsContext);

--- a/storybook/decorators/withDocsContainer.jsx
+++ b/storybook/decorators/withDocsContainer.jsx
@@ -1,5 +1,13 @@
 import { DocsContainer } from "@storybook/addon-docs";
 import { ShareGateTheme, ThemeProvider } from "@components/styling";
+import { createContext } from "react";
+import { useContext } from "react";
+
+const GlobalsContext = createContext();
+
+function GlobalsProvider({ globals, children }) {
+    return <GlobalsContext.Provider value={globals}>{children}</GlobalsContext.Provider>;
+}
 
 function ThemedDocsContainer({ context, children }) {
     const theme = context.globals.theme === "sharegate" ? ShareGateTheme : ShareGateTheme;
@@ -12,11 +20,21 @@ function ThemedDocsContainer({ context, children }) {
 }
 
 export function withDocsContainer(context, children) {
+    // The following line might not work on storybook@7.0.0
+    // If it still works, remove this comment.
+    // See https://github.com/storybookjs/storybook/issues/18477#issuecomment-1198852168
+    const story = context.storyById(context.id);
+    const { globals } = context.getStoryContext(story);
+
     return (
         <DocsContainer context={context}>
             <ThemedDocsContainer context={context}>
-                {children}
+                <GlobalsProvider globals={globals}>
+                    {children}
+                </GlobalsProvider>
             </ThemedDocsContainer>
         </DocsContainer>
     );
 }
+
+export const useGlobals = () => useContext(GlobalsContext);

--- a/storybook/decorators/withThemeProvider.jsx
+++ b/storybook/decorators/withThemeProvider.jsx
@@ -1,12 +1,11 @@
 import { ShareGateTheme, ThemeProvider } from "@components/styling";
 
-import { useGlobals } from "./withDocsContainer";
 import { isChromatic } from "../env";
+import { getGlobals } from "../utils";
 
 export function withThemeProvider(story, context) {
     const { viewMode } = context;
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const globals = useGlobals();
+    const globals = getGlobals(context);
 
     return (
         <ThemeProvider

--- a/storybook/decorators/withThemeProvider.jsx
+++ b/storybook/decorators/withThemeProvider.jsx
@@ -1,9 +1,12 @@
 import { ShareGateTheme, ThemeProvider } from "@components/styling";
 
+import { useGlobals } from "./withDocsContainer";
 import { isChromatic } from "../env";
 
 export function withThemeProvider(story, context) {
-    const { viewMode, globals } = context;
+    const { viewMode } = context;
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const globals = useGlobals();
 
     return (
         <ThemeProvider

--- a/storybook/utils/getGlobals.js
+++ b/storybook/utils/getGlobals.js
@@ -1,0 +1,23 @@
+/**
+ * The following function might not work on storybook@7.0.0
+ * 
+ * If it still works, remove this comment.
+ * 
+ * See https://github.com/storybookjs/storybook/issues/18477#issuecomment-1198852168
+ * @param { import("@storybook/react").StoryContext | import("@storybook/addon-docs").DocsContextProps } context
+ * @returns { Record<string, string> }
+ */
+export function getGlobals(context) {
+    // If it's a DocsContextProps, we have to do this to get up-to-date globals
+    // from the StoryContext.
+    if ( context.storyById && context.getStoryContext) {
+        const story = context.storyById(context.id);
+        const storyContext = context.getStoryContext(story);
+
+        return storyContext.globals;
+    }
+
+
+    // If it's a StoryContext, the context already has the up-to-date globals.
+    return context.globals;
+}

--- a/storybook/utils/getGlobals.js
+++ b/storybook/utils/getGlobals.js
@@ -10,7 +10,7 @@
 export function getGlobals(context) {
     // If it's a DocsContextProps, we have to do this to get up-to-date globals
     // from the StoryContext.
-    if ( context.storyById && context.getStoryContext) {
+    if (context.storyById && context.getStoryContext) {
         const story = context.storyById(context.id);
         const storyContext = context.getStoryContext(story);
 

--- a/storybook/utils/index.js
+++ b/storybook/utils/index.js
@@ -1,2 +1,3 @@
 export * from "./paramsBuilder";
 export * from "./storiesOfBuilder";
+export * from "./getGlobals";


### PR DESCRIPTION
## Summary

Fixes dark mode while still using the Storybook toolbar and `globals` variable.

## What I did
Turns out that the `context` variable can actually refer to two different objects: 
- **StoryContext** 
- **DocsContextProps**

**DocsContextProps.globals** is deprecated, so we need to add the two lines to access globals from the **StoryContext**:

```js
const story = docsContext.storyById(docsContext.id);
const storyContext = docsContext.getStoryContext(story);
```