### PR TITLE
Add missing icon button link docs example

### DIFF
--- a/packages/components/src/button/docs/Button.stories.mdx
+++ b/packages/components/src/button/docs/Button.stories.mdx
@@ -5,6 +5,7 @@ import {
     ButtonAsLink,
     ButtonGroup,
     IconButton,
+    IconButtonAsLink,
     InnerButton,
     InnerButtonGroup,
     InnerIconButton,
@@ -229,6 +230,16 @@ A button content can be a single icon. An accessible name must be provided throu
     </Story>
 </Preview>
 
+### Icon link
+
+An icon button can be rendered as a link by using the IconButtonAsLink component.
+
+<Preview>
+    <Story name="icon link button">
+        <IconButtonAsLink variant="secondary" aria-label="Add owner"><AddIcon /></IconButtonAsLink>
+    </Story>
+</Preview>
+
 ## Button group
 
 Buttons whose actions are related to each other can be grouped together.
@@ -383,4 +394,12 @@ A toggle button can handle `checked` state in controlled mode.
     compact
 />
 
-<ArgsTable of={InnerButton} sort="alpha" />
+### IconButtonAsLink
+
+<ComponentInfo
+    usage={"import { IconButtonAsLink } from \"@sharegate/orbit-ui\";"}
+    inherits={[InnerIconButton.defaultElement, "styled-component"]}
+    compact
+/>
+
+<ArgsTable of={InnerIconButton} sort="alpha" />

--- a/packages/components/src/button/docs/Button.stories.mdx
+++ b/packages/components/src/button/docs/Button.stories.mdx
@@ -394,6 +394,8 @@ A toggle button can handle `checked` state in controlled mode.
     compact
 />
 
+<ArgsTable of={InnerButton} sort="alpha" />
+
 ### IconButtonAsLink
 
 <ComponentInfo


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

## Summary

A doc examples for IconButtonAsLink was missing.