### PR TITLE
Export test was not running

### DIFF
--- a/packages/components/tests/jest/exports.test.ts
+++ b/packages/components/tests/jest/exports.test.ts
@@ -1,9 +1,9 @@
 import fs from "fs";
 import path from "path";
 
-const indexJs = fs.readFileSync(path.resolve(__dirname, "../src/index.ts"), "utf-8");
+const indexJs = fs.readFileSync(path.resolve(__dirname, "../../src/index.ts"), "utf-8");
 
-const directories = fs.readdirSync(path.resolve(__dirname, "../src"), { withFileTypes: true })
+const directories = fs.readdirSync(path.resolve(__dirname, "../../src"), { withFileTypes: true })
     .filter(x => x.isDirectory())
     .map(x => x.name);
 


### PR DESCRIPTION
## Summary

The test located in 
packages\components\tests\exports.test.ts

was not running since the jest config specifies
testMatch: **/tests/jest/*.test.ts?(x

and the test was not in a jest folder
## What I did

move the file inside a jest folder
