### PR TITLE
Allow eslint rule "testing-library/no-container" to run on unit tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,8 +27,7 @@ module.exports = {
                 "testing-library/prefer-find-by": "off", // multiple errors, should be fixed in another PR. 135 errors
                 "testing-library/no-node-access": "off", // multiple errors, should be fixed in another PR. 37 errors
                 "testing-library/render-result-naming-convention": "off", // multiple errors, should be fixed in another PR. 5 errors
-                "testing-library/prefer-presence-queries": "off", // multiple errors, should be fixed in another PR. 21 errors
-                "testing-library/no-container": "off"// multiple errors, should be fixed in another PR. 15 issues
+                "testing-library/prefer-presence-queries": "off" // multiple errors, should be fixed in another PR. 21 errors
             }
         },
         {

--- a/packages/components/src/autocomplete/tests/jest/Autocomplete.test.tsx
+++ b/packages/components/src/autocomplete/tests/jest/Autocomplete.test.tsx
@@ -116,7 +116,7 @@ test("when a query is cleared with backspaces, hide the overlay", async () => {
 });
 
 test("when a query is cleared with the clear button, hide the overlay", async () => {
-    const { container, getByTestId, queryByTestId } = renderWithTheme(
+    const { getByLabelText, getByTestId, queryByTestId } = renderWithTheme(
         <Autocomplete
             overlayProps={{ "data-testid": "overlay" }}
             aria-label="Planet"
@@ -136,7 +136,7 @@ test("when a query is cleared with the clear button, hide the overlay", async ()
     await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
     act(() => {
-        userEvent.click(container.querySelector(":scope .o-ui-search-input-clear-button"));
+        userEvent.click(getByLabelText("Clear value"));
     });
 
     await waitFor(() => expect(getByTestId("autocomplete")).toHaveValue(""));
@@ -456,7 +456,7 @@ test("when opened, on shift+tab keydown, close and select the previous tabbable 
 });
 
 test("when the clear button is clicked, the focus is moved to the input", async () => {
-    const { container, getByTestId } = renderWithTheme(
+    const { getByLabelText, getByTestId } = renderWithTheme(
         <Autocomplete
             overlayProps={{ "data-testid": "overlay" }}
             aria-label="Planet"
@@ -476,7 +476,7 @@ test("when the clear button is clicked, the focus is moved to the input", async 
     await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
 
     act(() => {
-        userEvent.click(container.querySelector(":scope .o-ui-search-input-clear-button"));
+        userEvent.click(getByLabelText("Clear value"));
     });
 
     await waitFor(() => expect(getByTestId("autocomplete")).toHaveFocus());

--- a/packages/components/src/date-input/tests/jest/DateInput.test.tsx
+++ b/packages/components/src/date-input/tests/jest/DateInput.test.tsx
@@ -292,7 +292,7 @@ test("when autofocus is specified with a de lay, the date input is focused after
 
 describe("compact presets", () => {
     test("when a preset is selected, both inputs are filled with the preset dates", async () => {
-        const { container, getByRole, getByPlaceholderText } = renderWithTheme(
+        const { getByRole, getByPlaceholderText, getByLabelText } = renderWithTheme(
             <DateInput
                 presets={[{ text: "Preset 1", date: new Date(2020, 0, 1) }]}
                 presetsVariant="compact"
@@ -301,7 +301,7 @@ describe("compact presets", () => {
         );
 
         act(() => {
-            userEvent.click(container.querySelector(":scope [aria-label=\"Date presets\"]"));
+            userEvent.click(getByLabelText("Date presets"));
         });
 
         await waitFor(() => expect(getByRole("menu")).toBeInTheDocument());
@@ -320,7 +320,7 @@ describe("compact presets", () => {
     });
 
     test("when a preset is selected, the preset menu trigger is focused", async () => {
-        const { container, getByRole } = renderWithTheme(
+        const { getByLabelText, getByRole } = renderWithTheme(
             <DateInput
                 presets={[{ text: "Preset 1", date: new Date(2020, 0, 1) }]}
                 presetsVariant="compact"
@@ -329,7 +329,7 @@ describe("compact presets", () => {
         );
 
         act(() => {
-            userEvent.click(container.querySelector(":scope [aria-label=\"Date presets\"]"));
+            userEvent.click(getByLabelText("Date presets"));
         });
 
         await waitFor(() => expect(getByRole("menu")).toBeInTheDocument());
@@ -338,11 +338,11 @@ describe("compact presets", () => {
             userEvent.click(getByRole("menuitemradio"));
         });
 
-        await waitFor(() => expect(container.querySelector(":scope [aria-label=\"Date presets\"]")).toHaveFocus());
+        await waitFor(() => expect(getByLabelText("Date presets")).toHaveFocus());
     });
 
     test("when a preset is selected from the menu, the selected item of the menu match the selected preset", async () => {
-        const { container, getByRole } = renderWithTheme(
+        const { getByLabelText, getByRole } = renderWithTheme(
             <DateInput
                 presets={[{ text: "Preset 1", date: new Date(2020, 0, 1) }]}
                 presetsVariant="compact"
@@ -351,7 +351,7 @@ describe("compact presets", () => {
         );
 
         act(() => {
-            userEvent.click(container.querySelector(":scope [aria-label=\"Date presets\"]"));
+            userEvent.click(getByLabelText("Date presets"));
         });
 
         await waitFor(() => expect(getByRole("menu")).toBeInTheDocument());
@@ -364,7 +364,7 @@ describe("compact presets", () => {
     });
 
     test("when the date value match a preset, the selected item of the menu match the preset", async () => {
-        const { container, getByRole } = renderWithTheme(
+        const { getByLabelText, getByRole } = renderWithTheme(
             <DateInput
                 value={new Date(2020, 0, 1)}
                 presets={[{ text: "Preset 1", date: new Date(2020, 0, 1) }]}
@@ -374,7 +374,7 @@ describe("compact presets", () => {
         );
 
         act(() => {
-            userEvent.click(container.querySelector(":scope [aria-label=\"Date presets\"]"));
+            userEvent.click(getByLabelText("Date presets"));
         });
 
         await waitFor(() => expect(getByRole("menu")).toBeInTheDocument());
@@ -676,7 +676,7 @@ test("when a valid date has been entered and the date exceed the specified min o
 test("when a preset is selected, call onDateChange with the preset date", async () => {
     const handler = jest.fn();
 
-    const { container, getByRole } = renderWithTheme(
+    const { getByLabelText, getByRole } = renderWithTheme(
         <DateInput
             presets={[{ text: "Preset 1", date: new Date(2020, 0, 1) }]}
             onDateChange={handler}
@@ -684,7 +684,7 @@ test("when a preset is selected, call onDateChange with the preset date", async 
     );
 
     act(() => {
-        userEvent.click(container.querySelector(":scope [aria-label=\"Date presets\"]"));
+        userEvent.click(getByLabelText("Date presets"));
     });
 
     await waitFor(() => expect(getByRole("menu")).toBeInTheDocument());

--- a/packages/components/src/date-input/tests/jest/DateRangeInput.test.tsx
+++ b/packages/components/src/date-input/tests/jest/DateRangeInput.test.tsx
@@ -27,10 +27,14 @@ function backspace(element: HTMLElement, times = 1) {
 }
 
 function getStartDateInput(container: HTMLElement, name = "date-range") {
+    // containers are used here since we can't find the input by name otherwise,
+    // and we can't use placeholder since it's the same for the start and end date inputs
     return container.querySelector(`:scope [name=${name}-start-date]`) as HTMLElement;
 }
 
 function getEndDateInput(container: HTMLElement, name = "date-range") {
+    // containers are used here since we can't find the input by name otherwise,
+    // and we can't use placeholder since it's the same for the start and end date inputs
     return container.querySelector(`:scope [name=${name}-end-date]`) as HTMLElement;
 }
 
@@ -453,7 +457,7 @@ test("when autofocus is specified with a delay, the date range input is focused 
 
 describe("compact presets", () => {
     test("when a preset is selected, both inputs are filled with the preset dates", async () => {
-        const { container, getByRole } = renderWithTheme(
+        const { container, getByRole, getByLabelText } = renderWithTheme(
             <DateRangeInput
                 presets={[{ text: "Preset 1", startDate: new Date(2020, 0, 1), endDate: new Date(2020, 0, 7) }]}
                 presetsVariant="compact"
@@ -462,7 +466,7 @@ describe("compact presets", () => {
         );
 
         act(() => {
-            userEvent.click(container.querySelector(":scope [aria-label=\"Date presets\"]"));
+            userEvent.click(getByLabelText("Date presets"));
         });
 
         await waitFor(() => expect(getByRole("menu")).toBeInTheDocument());
@@ -488,7 +492,7 @@ describe("compact presets", () => {
     });
 
     test("when a preset is selected, the preset menu trigger is focused", async () => {
-        const { container, getByRole } = renderWithTheme(
+        const { getByRole, getByLabelText } = renderWithTheme(
             <DateRangeInput
                 presets={[{ text: "Preset 1", startDate: new Date(2020, 0, 1), endDate: new Date(2020, 0, 7) }]}
                 presetsVariant="compact"
@@ -497,7 +501,7 @@ describe("compact presets", () => {
         );
 
         act(() => {
-            userEvent.click(container.querySelector(":scope [aria-label=\"Date presets\"]"));
+            userEvent.click(getByLabelText("Date presets"));
         });
 
         await waitFor(() => expect(getByRole("menu")).toBeInTheDocument());
@@ -506,11 +510,11 @@ describe("compact presets", () => {
             userEvent.click(getByRole("menuitemradio"));
         });
 
-        await waitFor(() => expect(container.querySelector(":scope [aria-label=\"Date presets\"]")).toHaveFocus());
+        await waitFor(() => expect(getByLabelText("Date presets")).toHaveFocus());
     });
 
     test("when a preset is selected from the menu, the selected item of the menu match the selected preset", async () => {
-        const { container, getByRole } = renderWithTheme(
+        const { getByLabelText, getByRole } = renderWithTheme(
             <DateRangeInput
                 presets={[{ text: "Preset 1", startDate: new Date(2020, 0, 1), endDate: new Date(2020, 0, 7) }]}
                 presetsVariant="compact"
@@ -519,7 +523,7 @@ describe("compact presets", () => {
         );
 
         act(() => {
-            userEvent.click(container.querySelector(":scope [aria-label=\"Date presets\"]"));
+            userEvent.click(getByLabelText("Date presets"));
         });
 
         await waitFor(() => expect(getByRole("menu")).toBeInTheDocument());
@@ -532,7 +536,7 @@ describe("compact presets", () => {
     });
 
     test("when dates match a preset, the selected item of the menu match the preset", async () => {
-        const { container, getByRole } = renderWithTheme(
+        const { getByLabelText, getByRole } = renderWithTheme(
             <DateRangeInput
                 startDate={new Date(2020, 0, 1)}
                 endDate={new Date(2020, 0, 7)}
@@ -543,7 +547,7 @@ describe("compact presets", () => {
         );
 
         act(() => {
-            userEvent.click(container.querySelector(":scope [aria-label=\"Date presets\"]"));
+            userEvent.click(getByLabelText("Date presets"));
         });
 
         await waitFor(() => expect(getByRole("menu")).toBeInTheDocument());
@@ -737,7 +741,7 @@ test("when the dates are cleared, call onDatesChange with null for both dates", 
 test("when a preset is selected, call onDatesChange with both dates", async () => {
     const handler = jest.fn();
 
-    const { container, getByRole } = renderWithTheme(
+    const { getByLabelText, getByRole } = renderWithTheme(
         <DateRangeInput
             presets={[{ text: "Preset 1", startDate: new Date(2020, 0, 1), endDate: new Date(2020, 0, 7) }]}
             onDatesChange={handler}
@@ -746,7 +750,7 @@ test("when a preset is selected, call onDatesChange with both dates", async () =
     );
 
     act(() => {
-        userEvent.click(container.querySelector(":scope [aria-label=\"Date presets\"]"));
+        userEvent.click(getByLabelText("Date presets"));
     });
 
     await waitFor(() => expect(getByRole("menu")).toBeInTheDocument());

--- a/packages/components/src/text-input/tests/jest/SearchInput.test.tsx
+++ b/packages/components/src/text-input/tests/jest/SearchInput.test.tsx
@@ -122,7 +122,7 @@ test("call onValueChange when the value change", async () => {
 test("call onValueChange when the value is cleared", async () => {
     const handler = jest.fn();
 
-    const { getByTestId, container } = renderWithTheme(
+    const { getByTestId, getByLabelText } = renderWithTheme(
         <SearchInput onValueChange={handler} aria-label="Label" data-testid="input" />
     );
 
@@ -132,7 +132,7 @@ test("call onValueChange when the value is cleared", async () => {
 
     await act(() => userEvent.type(getByTestId("input"), "a"));
 
-    await act(() => userEvent.click(container.querySelector(".o-ui-search-input-clear-button")));
+    await act(() => userEvent.click(getByLabelText("Clear value")));
 
     await waitFor(() => expect(handler).toHaveBeenLastCalledWith(expect.anything(), ""));
     await waitFor(() => expect(handler).toHaveBeenCalledTimes(2));


### PR DESCRIPTION
By using container methods like .querySelector you may lose a lot of the confidence that the user can really interact with your UI. Also, the test becomes harder to read, and it will break more frequently.

related to https://github.com/gsoft-inc/sg-orbit/issues/1099

