### PR TITLE
Toggle testing-library/prefer-presence-queries

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,8 +25,7 @@ module.exports = {
                 "testing-library/no-unnecessary-act": "off", // multiple errors, should be fixed in another PR. 515 errors
                 "testing-library/prefer-screen-queries": "off", // multiple errors, should be fixed in another PR. 1343 errors
                 "testing-library/prefer-find-by": "off", // multiple errors, should be fixed in another PR. 135 errors
-                "testing-library/no-node-access": "off", // multiple errors, should be fixed in another PR. 37 errors
-                "testing-library/prefer-presence-queries": "off" // multiple errors, should be fixed in another PR. 21 errors
+                "testing-library/no-node-access": "off" // multiple errors, should be fixed in another PR. 37 errors
             }
         },
         {

--- a/packages/components/src/dialog/tests/jest/DialogTrigger.test.tsx
+++ b/packages/components/src/dialog/tests/jest/DialogTrigger.test.tsx
@@ -117,7 +117,7 @@ test("when dismissable is false, do not close the dialog on outside click", asyn
         userEvent.click(document.body);
     });
 
-    await waitFor(() => expect(queryByTestId("dialog")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("dialog")).toBeInTheDocument());
 });
 
 test("when dismissable is false, do not close the dialog on esc keypress", async () => {
@@ -141,7 +141,7 @@ test("when dismissable is false, do not close the dialog on esc keypress", async
         fireEvent.keyDown(getByTestId("dialog"), { key: Keys.esc });
     });
 
-    await waitFor(() => expect(queryByTestId("dialog")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("dialog")).toBeInTheDocument());
 });
 
 test("when the context close function is called, close the dialog", async () => {
@@ -172,7 +172,7 @@ test("when the context close function is called, close the dialog", async () => 
         userEvent.click(getByTestId("trigger"));
     });
 
-    await waitFor(() => expect(queryByTestId("close-btn")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("close-btn")).toBeInTheDocument());
 
     act(() => {
         userEvent.click(getByTestId("close-btn"));
@@ -357,7 +357,7 @@ test("set ref once", async () => {
 // ***** Nested overlay components *****
 
 test("when a dialog contains a select component, focusing an option do not close the dialog", async () => {
-    const { getByTestId, queryByTestId } = renderWithTheme(
+    const { getByTestId } = renderWithTheme(
         <DialogTrigger>
             <Button data-testid="trigger">Trigger</Button>
             <Dialog data-testid="dialog">
@@ -381,24 +381,24 @@ test("when a dialog contains a select component, focusing an option do not close
         userEvent.click(getByTestId("trigger"));
     });
 
-    await waitFor(() => expect(queryByTestId("dialog")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("dialog")).toBeInTheDocument());
 
     act(() => {
         userEvent.click(getByTestId("select"));
     });
 
-    await waitFor(() => expect(queryByTestId("select-overlay")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("select-overlay")).toBeInTheDocument());
 
     act(() => {
         getByTestId("option-2").focus();
     });
 
-    await waitFor(() => expect(queryByTestId("select-overlay")).toBeInTheDocument());
-    await waitFor(() => expect(queryByTestId("dialog")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("select-overlay")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("dialog")).toBeInTheDocument());
 });
 
 test("when a dialog contains a select component, selecting an option do not close the dialog", async () => {
-    const { getByTestId, queryByTestId } = renderWithTheme(
+    const { getByTestId } = renderWithTheme(
         <DialogTrigger>
             <Button data-testid="trigger">Trigger</Button>
             <Dialog data-testid="dialog">
@@ -422,19 +422,19 @@ test("when a dialog contains a select component, selecting an option do not clos
         userEvent.click(getByTestId("trigger"));
     });
 
-    await waitFor(() => expect(queryByTestId("dialog")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("dialog")).toBeInTheDocument());
 
     act(() => {
         userEvent.click(getByTestId("select"));
     });
 
-    await waitFor(() => expect(queryByTestId("select-overlay")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("select-overlay")).toBeInTheDocument());
 
     act(() => {
         userEvent.click(getByTestId("option-2"));
     });
 
-    await waitFor(() => expect(queryByTestId("dialog")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("dialog")).toBeInTheDocument());
 });
 
 test("when a dialog contains a select, closing the select with an esc keydown do not close the dialog", async () => {
@@ -462,13 +462,13 @@ test("when a dialog contains a select, closing the select with an esc keydown do
         userEvent.click(getByTestId("trigger"));
     });
 
-    await waitFor(() => expect(queryByTestId("dialog")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("dialog")).toBeInTheDocument());
 
     act(() => {
         userEvent.click(getByTestId("select"));
     });
 
-    await waitFor(() => expect(queryByTestId("select-overlay")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("select-overlay")).toBeInTheDocument());
 
     act(() => {
         getByTestId("option-2").focus();
@@ -479,7 +479,7 @@ test("when a dialog contains a select, closing the select with an esc keydown do
     });
 
     await waitFor(() => expect(queryByTestId("select-overlay")).not.toBeInTheDocument());
-    await waitFor(() => expect(queryByTestId("dialog")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("dialog")).toBeInTheDocument());
 });
 
 test("when a dialog contains a select, closing the select with a tab keydown select the next focusable element of the dialog", async () => {
@@ -508,13 +508,13 @@ test("when a dialog contains a select, closing the select with a tab keydown sel
         userEvent.click(getByTestId("trigger"));
     });
 
-    await waitFor(() => expect(queryByTestId("dialog")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("dialog")).toBeInTheDocument());
 
     act(() => {
         userEvent.click(getByTestId("select"));
     });
 
-    await waitFor(() => expect(queryByTestId("select-overlay")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("select-overlay")).toBeInTheDocument());
 
     act(() => {
         getByTestId("option-2").focus();
@@ -526,7 +526,7 @@ test("when a dialog contains a select, closing the select with a tab keydown sel
 
     await waitFor(() => expect(queryByTestId("select-overlay")).not.toBeInTheDocument());
     await waitFor(() => expect(queryByTestId("button")).toHaveFocus());
-    await waitFor(() => expect(queryByTestId("dialog")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("dialog")).toBeInTheDocument());
 });
 
 test("when a dialog contains a radio group, only the first radio of the group is focused with tabbulation", async () => {
@@ -553,7 +553,7 @@ test("when a dialog contains a radio group, only the first radio of the group is
         userEvent.click(getByTestId("trigger"));
     });
 
-    await waitFor(() => expect(queryByTestId("dialog")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("dialog")).toBeInTheDocument());
 
     act(() => {
         getByTestId("button-1").focus();

--- a/packages/components/src/image/tests/jest/SvgImage.test.tsx
+++ b/packages/components/src/image/tests/jest/SvgImage.test.tsx
@@ -53,11 +53,11 @@ test("an aria-hidden attribute is added to all the path elements of the svg", as
 });
 
 test("remove the title element of the svg", async () => {
-    const { getByTestId } = renderWithTheme(
+    const { queryByTestId } = renderWithTheme(
         <SvgImage data-testid="svg" src={SvgWithTitle} aria-label="Basic SVG" />
     );
 
-    await waitFor(() => expect(getByTestId("svg").querySelector("title")).toBeNull());
+    await waitFor(() => expect(queryByTestId("svg").querySelector("title")).toBeNull());
 });
 
 // ***** Refs *****

--- a/packages/components/src/overlay/tests/jest/usePopup.test.tsx
+++ b/packages/components/src/overlay/tests/jest/usePopup.test.tsx
@@ -190,7 +190,7 @@ describe("\"click\" trigger", () => {
     });
 
     test("when opened and hideOnTriggerClick is false, do not close on trigger click", async () => {
-        const { getByTestId, queryByTestId } = renderWithTheme(
+        const { getByTestId } = renderWithTheme(
             <Popup
                 hideOnTriggerClick={false}
                 trigger="click"
@@ -209,7 +209,7 @@ describe("\"click\" trigger", () => {
             userEvent.click(getByTestId("trigger"));
         });
 
-        await waitFor(() => expect(queryByTestId("overlay")).toBeInTheDocument());
+        await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
     });
 
     test("when opened, close on esc keypress", async () => {

--- a/packages/components/src/popover/tests/jest/PopoverTrigger.test.tsx
+++ b/packages/components/src/popover/tests/jest/PopoverTrigger.test.tsx
@@ -154,7 +154,7 @@ test("when a popover is not dismissable, do not hide the popover on trigger togg
         userEvent.click(getByTestId("trigger"));
     });
 
-    await waitFor(() => expect(queryByTestId("popover")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("popover")).toBeInTheDocument());
 });
 
 test("when the context close function is called, close the dialog", async () => {
@@ -185,7 +185,7 @@ test("when the context close function is called, close the dialog", async () => 
         userEvent.click(getByTestId("trigger"));
     });
 
-    await waitFor(() => expect(queryByTestId("close-btn")).toBeInTheDocument());
+    await waitFor(() => expect(getByTestId("close-btn")).toBeInTheDocument());
 
     act(() => {
         userEvent.click(getByTestId("close-btn"));


### PR DESCRIPTION
The (DOM) Testing Library allows to query DOM elements using different types of queries such as get* and query*. Using get* throws an error in case the element is not found, while query* returns null instead of throwing (or empty array for queryAllBy* ones). These differences are useful in some situations:

- using getBy* queries when asserting if element is present, so if the element is not found the error thrown will offer better info than asserting with other queries which will not throw an error.
- using queryBy* queries when asserting if element is not present, so the test doesn't fail immediately when the element is not found and the assertion can be executed properly.

Related to https://github.com/gsoft-inc/sg-orbit/issues/1099
