### PR TITLE
Toggle testing-library/no-node-access

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,8 +24,7 @@ module.exports = {
                 "jest/no-commented-out-tests": "off", // TODO remove this when we fix all commented out tests
                 "testing-library/no-unnecessary-act": "off", // multiple errors, should be fixed in another PR. 515 errors
                 "testing-library/prefer-screen-queries": "off", // multiple errors, should be fixed in another PR. 1343 errors
-                "testing-library/prefer-find-by": "off", // multiple errors, should be fixed in another PR. 135 errors
-                "testing-library/no-node-access": "off" // multiple errors, should be fixed in another PR. 37 errors
+                "testing-library/prefer-find-by": "off" // multiple errors, should be fixed in another PR. 135 errors
             }
         },
         {

--- a/packages/components/src/alert/tests/jest/Alert.test.tsx
+++ b/packages/components/src/alert/tests/jest/Alert.test.tsx
@@ -8,47 +8,47 @@ import { waitFor } from "@testing-library/react";
 // ***** Behaviors *****
 
 test("when autoFocusButton value is \"primary\", autofocus the primary button on render", async () => {
-    const { getByText } = renderWithTheme(
+    const { getByRole } = renderWithTheme(
         <Alert autoFocusButton="primary" primaryButtonLabel="Primary" secondaryButtonLabel="Secondary" cancelButtonLabel="Cancel">
             <Heading>Autopilot</Heading>
             <Content>Are you sure you want to engage autopilot?</Content>
         </Alert>
     );
 
-    await waitFor(() => expect(getByText("Primary").parentElement).toHaveFocus());
+    await waitFor(() => expect(getByRole("button", { name: "Primary" })).toHaveFocus());
 });
 
 test("when autoFocusButton value is \"secondary\", autofocus the secondary button on render", async () => {
-    const { getByText } = renderWithTheme(
+    const { getByRole } = renderWithTheme(
         <Alert autoFocusButton="secondary" primaryButtonLabel="Primary" secondaryButtonLabel="Secondary" cancelButtonLabel="Cancel">
             <Heading>Autopilot</Heading>
             <Content>Are you sure you want to engage autopilot?</Content>
         </Alert>
     );
 
-    await waitFor(() => expect(getByText("Secondary").parentElement).toHaveFocus());
+    await waitFor(() => expect(getByRole("button", { name: "Secondary" })).toHaveFocus());
 });
 
 test("when autoFocusButton value is \"cancel\", autofocus the cancel button on render", async () => {
-    const { getByText } = renderWithTheme(
+    const { getByRole } = renderWithTheme(
         <Alert autoFocusButton="cancel" primaryButtonLabel="Primary" secondaryButtonLabel="Secondary" cancelButtonLabel="Cancel">
             <Heading>Autopilot</Heading>
             <Content>Are you sure you want to engage autopilot?</Content>
         </Alert>
     );
 
-    await waitFor(() => expect(getByText("Cancel").parentElement).toHaveFocus());
+    await waitFor(() => expect(getByRole("button", { name: "Cancel" })).toHaveFocus());
 });
 
 test("when autoFocusButton value is not defined, autofocus the primary button", async () => {
-    const { getByText } = renderWithTheme(
+    const { getByRole } = renderWithTheme(
         <Alert primaryButtonLabel="Primary" secondaryButtonLabel="Secondary" cancelButtonLabel="Cancel">
             <Heading>Autopilot</Heading>
             <Content>Are you sure you want to engage autopilot?</Content>
         </Alert>
     );
 
-    await waitFor(() => expect(getByText("Primary").parentElement).toHaveFocus());
+    await waitFor(() => expect(getByRole("button", { name: "Primary" })).toHaveFocus());
 });
 
 // ***** Refs *****

--- a/packages/components/src/autocomplete/tests/jest/Autocomplete.test.tsx
+++ b/packages/components/src/autocomplete/tests/jest/Autocomplete.test.tsx
@@ -42,11 +42,12 @@ test("when a query matching existing values is entered, open the overlay with th
 });
 
 test("when a query matching no values is entered, open the overlay with a not found message", async () => {
-    const { getByTestId } = renderWithTheme(
+    const { getByTestId, getByText } = renderWithTheme(
         <Autocomplete
             overlayProps={{ "data-testid": "overlay" }}
             aria-label="Planet"
             data-testid="autocomplete"
+            noResultsMessage="No results."
         >
             <Item key="earth">Earth</Item>
             <Item key="jupiter">Jupiter</Item>
@@ -60,7 +61,7 @@ test("when a query matching no values is entered, open the overlay with a not fo
     act(() => getByTestId("autocomplete").focus());
 
     await waitFor(() => expect(getByTestId("overlay")).toBeInTheDocument());
-    await waitFor(() => expect(getByTestId("overlay")).toContainElement(getByTestId("overlay").querySelector(".o-ui-autocomplete-no-results")));
+    await waitFor(() => expect(getByTestId("overlay")).toContainElement(getByText("No results.")));
 });
 
 test("when opening, the focus stay on the input", async () => {

--- a/packages/components/src/image/tests/jest/SvgImage.test.tsx
+++ b/packages/components/src/image/tests/jest/SvgImage.test.tsx
@@ -45,6 +45,8 @@ test("an aria-hidden attribute is added to all the path elements of the svg", as
         <SvgImage data-testid="svg" src={BasicSvg} aria-label="Basic SVG" />
     );
 
+    // In this specific case, we really want to iterate over the path elements
+    // eslint-disable-next-line testing-library/no-node-access
     const paths = getByTestId("svg").querySelectorAll("path");
 
     await waitFor(() => expect(paths[0]).toHaveAttribute("aria-hidden", "true"));
@@ -57,6 +59,8 @@ test("remove the title element of the svg", async () => {
         <SvgImage data-testid="svg" src={SvgWithTitle} aria-label="Basic SVG" />
     );
 
+    // In this specific case, we really want find a child element of the svg via its DOM type
+    // eslint-disable-next-line testing-library/no-node-access
     await waitFor(() => expect(queryByTestId("svg").querySelector("title")).toBeNull());
 });
 

--- a/packages/components/src/listbox/tests/jest/Listbox.test.tsx
+++ b/packages/components/src/listbox/tests/jest/Listbox.test.tsx
@@ -96,7 +96,7 @@ test("down arrow keypress moves focus to the next option", async () => {
         fireEvent.keyDown(getByTestId("earth-option"), { key: Keys.arrowDown });
     });
 
-    await waitFor(() => expect(document.activeElement).toBe(getByTestId("jupiter-option")));
+    await waitFor(() => expect(getByTestId("jupiter-option")).toHaveFocus());
 });
 
 test("up arrow keypress moves focus to the previous option", async () => {
@@ -120,7 +120,7 @@ test("up arrow keypress moves focus to the previous option", async () => {
         fireEvent.keyDown(getByTestId("jupiter-option"), { key: Keys.arrowUp });
     });
 
-    await waitFor(() => expect(document.activeElement).toBe(getByTestId("earth-option")));
+    await waitFor(() => expect(getByTestId("earth-option")).toHaveFocus());
 });
 
 test("home keypress move the focus to the first option", async () => {
@@ -144,7 +144,7 @@ test("home keypress move the focus to the first option", async () => {
         fireEvent.keyDown(getByTestId("jupiter-option"), { key: Keys.home });
     });
 
-    await waitFor(() => expect(document.activeElement).toBe(getByTestId("earth-option")));
+    await waitFor(() => expect(getByTestId("earth-option")).toHaveFocus());
 });
 
 test("end keypress move the focus to the last option", async () => {
@@ -164,7 +164,7 @@ test("end keypress move the focus to the last option", async () => {
         fireEvent.keyDown(getByTestId("earth-option"), { key: Keys.end });
     });
 
-    await waitFor(() => expect(document.activeElement).toBe(getByTestId("mars-option")));
+    await waitFor(() => expect(getByTestId("mars-option")).toHaveFocus());
 });
 
 test("when selectionMode is \"none\", spacebar keypress don't toggle the option selection", async () => {

--- a/packages/components/src/menu/tests/jest/Menu.test.tsx
+++ b/packages/components/src/menu/tests/jest/Menu.test.tsx
@@ -110,7 +110,7 @@ test("down arrow keypress moves focus to the next item", async () => {
         fireEvent.keyDown(getByTestId("earth-item"), { key: Keys.arrowDown });
     });
 
-    await waitFor(() => expect(document.activeElement).toBe(getByTestId("jupiter-item")));
+    await waitFor(() => expect(getByTestId("jupiter-item")).toHaveFocus());
 });
 
 test("up arrow keypress moves focus to the previous item", async () => {
@@ -134,7 +134,7 @@ test("up arrow keypress moves focus to the previous item", async () => {
         fireEvent.keyDown(getByTestId("jupiter-item"), { key: Keys.arrowUp });
     });
 
-    await waitFor(() => expect(document.activeElement).toBe(getByTestId("earth-item")));
+    await waitFor(() => expect(getByTestId("earth-item")).toHaveFocus());
 });
 
 test("home keypress move the focus to the first item", async () => {
@@ -158,7 +158,7 @@ test("home keypress move the focus to the first item", async () => {
         fireEvent.keyDown(getByTestId("jupiter-item"), { key: Keys.home });
     });
 
-    await waitFor(() => expect(document.activeElement).toBe(getByTestId("earth-item")));
+    await waitFor(() => expect(getByTestId("earth-item")).toHaveFocus());
 });
 
 test("end keypress move the focus to the last item", async () => {
@@ -178,7 +178,7 @@ test("end keypress move the focus to the last item", async () => {
         fireEvent.keyDown(getByTestId("earth-item"), { key: Keys.end });
     });
 
-    await waitFor(() => expect(document.activeElement).toBe(getByTestId("mars-item")));
+    await waitFor(() => expect(getByTestId("mars-item")).toHaveFocus());
 });
 
 test("when selectionMode is \"none\", spacebar keypress don't toggle the item selection", async () => {

--- a/packages/components/src/select/tests/jest/Select.test.tsx
+++ b/packages/components/src/select/tests/jest/Select.test.tsx
@@ -390,7 +390,7 @@ test("when an aria-label and an aria-labelledby are provided, do not set aria-la
 });
 
 test("when no aria-label and no aria-labelledby are provided, set the trigger id as listbox aria-labelledby", async () => {
-    const { getByTestId } = renderWithTheme(
+    const { getByRole } = renderWithTheme(
         <Select
             id="planets"
             defaultOpen
@@ -402,7 +402,7 @@ test("when no aria-label and no aria-labelledby are provided, set the trigger id
         </Select>
     );
 
-    await waitFor(() => expect(getByTestId("overlay").querySelector(".o-ui-listbox")).toHaveAttribute("aria-labelledby", "planets"));
+    await waitFor(() => expect(getByRole("listbox")).toHaveAttribute("aria-labelledby", "planets"));
 });
 
 // ***** Api *****

--- a/packages/components/src/shared/tests/jest/useRawSlots.test.tsx
+++ b/packages/components/src/shared/tests/jest/useRawSlots.test.tsx
@@ -50,6 +50,8 @@ test("can parse a single static slot", () => {
     const { result } = renderHook(() => useRawSlots(children, ["title"]));
 
     expect(result.current.title).not.toBeUndefined();
+    // False positive, we are accessing the children prop
+    // eslint-disable-next-line testing-library/no-node-access
     expect(result.current.title.props.children).toBe(title);
 });
 
@@ -80,6 +82,8 @@ test("can parse a dynamic slot", () => {
     const { result } = renderHook(() => useRawSlots(children, ["title"]));
 
     expect(result.current.title).not.toBeUndefined();
+    // False positive, we are accessing the children prop
+    // eslint-disable-next-line testing-library/no-node-access
     expect(result.current.title.props.children).toBe(title);
 });
 

--- a/packages/components/src/text-input/tests/jest/SearchInput.test.tsx
+++ b/packages/components/src/text-input/tests/jest/SearchInput.test.tsx
@@ -11,7 +11,7 @@ function getInput(element: Element) {
 }
 
 test("clear value on clear button click", async () => {
-    const { getByTestId } = renderWithTheme(
+    const { getByTestId, getByLabelText } = renderWithTheme(
         <SearchInput
             data-testid="input"
             wrapperProps={{
@@ -25,7 +25,7 @@ test("clear value on clear button click", async () => {
     await waitFor(() => expect(getInput(getByTestId("input")).value).toBe("Mars"));
 
     act(() => {
-        fireEvent.click(getByTestId("input-wrapper").querySelector(":scope button"));
+        fireEvent.click(getByLabelText("Clear value"));
     });
 
     await waitFor(() => expect(getInput(getByTestId("input")).value).toBe(""));
@@ -46,7 +46,7 @@ test("clear value on esc", async () => {
 });
 
 test("focus input on clear", async () => {
-    const { getByTestId } = renderWithTheme(
+    const { getByTestId, getByLabelText } = renderWithTheme(
         <SearchInput
             data-testid="input"
             wrapperProps={{
@@ -58,7 +58,7 @@ test("focus input on clear", async () => {
     );
 
     act(() => {
-        fireEvent.click(getByTestId("input-wrapper").querySelector(":scope button"));
+        fireEvent.click(getByLabelText("Clear value"));
     });
 
     await waitFor(() => expect(getByTestId("input")).toHaveFocus());

--- a/packages/components/src/tooltip/tests/jest/TooltipTrigger.test.tsx
+++ b/packages/components/src/tooltip/tests/jest/TooltipTrigger.test.tsx
@@ -45,7 +45,9 @@ test("when the trigger is disabled, close on trigger leave", async () => {
     await waitFor(() => expect(getByTestId("tooltip")).toBeInTheDocument());
 
     act(() => {
-        fireEvent.mouseLeave(getByTestId("trigger"));
+        // fireEvent.mouseLeave() doesn't fire when the element is disabled, so we take its parent
+        // eslint-disable-next-line testing-library/no-node-access
+        fireEvent.mouseLeave(getByTestId("trigger").parentElement);
     });
 
     await waitFor(() => expect(queryByTestId("tooltip")).not.toBeInTheDocument());

--- a/packages/components/src/tooltip/tests/jest/TooltipTrigger.test.tsx
+++ b/packages/components/src/tooltip/tests/jest/TooltipTrigger.test.tsx
@@ -45,7 +45,7 @@ test("when the trigger is disabled, close on trigger leave", async () => {
     await waitFor(() => expect(getByTestId("tooltip")).toBeInTheDocument());
 
     act(() => {
-        fireEvent.mouseLeave(getByTestId("trigger").parentElement);
+        fireEvent.mouseLeave(getByTestId("trigger"));
     });
 
     await waitFor(() => expect(queryByTestId("tooltip")).not.toBeInTheDocument());


### PR DESCRIPTION
This rule aims to disallow DOM traversal using native HTML methods and properties, such as closest, lastChild and all that returns another Node element from an HTML tree.

Related to https://github.com/gsoft-inc/sg-orbit/issues/1099