### PR TITLE
#1141 Tooltips often stay open when hovered fast

### DIFF
--- a/packages/components/src/tooltip/src/TooltipTrigger.tsx
+++ b/packages/components/src/tooltip/src/TooltipTrigger.tsx
@@ -7,7 +7,6 @@ import {
     isNil,
     mergeProps,
     resolveChildren,
-    useControllableState,
     useEventCallback,
     useId,
     useMergedRefs
@@ -17,6 +16,7 @@ import { useResponsiveValue, useThemeContext } from "../../styling";
 
 import { Div } from "../../html";
 import { TooltipTriggerContext } from "./TooltipTriggerContext";
+import { useTooltipTriggerState } from "./useTooltipTriggerState";
 
 const DefaultElement = "div";
 
@@ -95,7 +95,7 @@ export function InnerTooltipTrigger({
 
     const { themeAccessor } = useThemeContext();
 
-    const [isOpen, setIsOpen] = useControllableState(open, defaultOpen, false);
+    const { isOpen, setIsOpen } = useTooltipTriggerState(open, defaultOpen, false);
 
     const updateIsOpen = useCallback((event: SyntheticEvent, newValue: boolean) => {
         if (isOpen !== newValue) {
@@ -126,7 +126,7 @@ export function InnerTooltipTrigger({
         isDisabled: disabled,
         onHide: useEventCallback((event: SyntheticEvent) => {
             // Prevent from closing when the focus goes to an element of the overlay on opening.
-            if (!isTargetParent((event as FocusEvent).relatedTarget, overlayRef)) {
+            if (event.type !== "blur" || !isTargetParent((event as FocusEvent).relatedTarget, overlayRef)) {
                 updateIsOpen(event, false);
             }
         }),

--- a/packages/components/src/tooltip/src/useTooltipTriggerState.ts
+++ b/packages/components/src/tooltip/src/useTooltipTriggerState.ts
@@ -1,0 +1,55 @@
+import { useEffect, useMemo } from "react";
+import { useControllableState } from "../../shared";
+
+export interface OverlayTriggerState {
+    readonly isOpen: boolean;
+    setIsOpen: (isOpen: boolean) => void;
+}
+
+const tooltips:Record<string, () => void> = {};
+let tooltipId = 0;
+
+
+/*
+ * Manages state for a tooltip trigger. Tracks whether the tooltip is open, and provides
+ * methods to toggle this state. Ensures only one tooltip is open at a time
+*/
+export function useTooltipTriggerState(defaultOpen: boolean, open: boolean, defaultValue = false): OverlayTriggerState {
+    const [isOpen, setIsOpen] = useControllableState(open, defaultOpen, defaultValue);
+    const id = useMemo(() => `${++tooltipId}`, []);
+
+    const ensureTooltipEntry = () => {
+        tooltips[id] = () => setIsOpen(false);
+    };
+
+    const closeOpenTooltips = () => {
+        for (const hideTooltipId in tooltips) {
+            if (hideTooltipId !== id) {
+                tooltips[hideTooltipId]();
+                delete tooltips[hideTooltipId];
+            }
+        }
+    };
+
+    useEffect(() => {
+        return () => {
+            const tooltip = tooltips[id];
+            if (tooltip) {
+                delete tooltips[id];
+            }
+        };
+    }, [id]);
+
+    return {
+        isOpen,
+        setIsOpen: (value: boolean) => {
+            if (value) {
+                setIsOpen(true);
+                closeOpenTooltips();
+                ensureTooltipEntry();
+            } else {
+                setIsOpen(false);
+            }
+        }
+    };
+}


### PR DESCRIPTION
## Summary

Tooltips now open one at the time, never multiple at once. Also fixed an issue where mouseLeave event would not be detected anymore when hovering the overlay

## What I did

The condition 
```
if (!isTargetParent((event as FocusEvent).relatedTarget, overlayRef)) {
```
really was the issue. It was intended for blur events, but was preventing mouseLeave event from firing if the mouseleave was on the overlay. 

added a check to make sure only blur event were taking into consideration for this logic