### PR TITLE
Reworked dialog to be bulletproof when an image is inside

### DIFF
--- a/packages/components/src/dialog/src/Dialog.css
+++ b/packages/components/src/dialog/src/Dialog.css
@@ -23,6 +23,7 @@
     background-color: var(--o-ui-bg-alias-surface);
     border-radius: var(--o-ui-br-4);
     display: grid;
+    overflow: hidden;
     align-items: stretch;
     grid-template-areas: "image image" "aside aside";
     grid-template-rows: min-content auto;
@@ -63,8 +64,8 @@
 .o-ui-dialog-illustration {
     width: 100%;
     height: var(--o-ui-sz-14);
-    border-top-left-radius: inherit;
-    border-bottom-left-radius: inherit;
+    /* border-top-left-radius: inherit;
+    border-bottom-left-radius: inherit; */
     grid-area: image;
     overflow: hidden;
 }


### PR DESCRIPTION
Issue: 

## Summary

#1150 - Modal with image on mobile does not have the right corners rounded

## What I did

Added an overflow hidden to the Dialog and removed the Image and Illustration context specific border radius as it's now the Dialog job to deal with that. This is working since the focus state of a Dialog is inside, to make it visible when an overlay is present.