### PR TITLE
[Draft]

### DIFF
--- a/packages/components/src/tooltip/src/Tooltip.css
+++ b/packages/components/src/tooltip/src/Tooltip.css
@@ -1,3 +1,16 @@
+.o-ui-tooltip-wrapper {
+    max-width: var(--o-ui-sz-16);
+
+    --o-ui-tooltip-arrow-border-color: var(--o-ui-focus-ring-color-alias-default);
+    --o-ui-tooltip-arrow-dimension: 10px;
+    /* since we take a 10px by 10px and add a transformation of 45, we get a lozenge. the height of that lozenge can be calculated using
+       sqrt(var(--o-ui-tooltip-arrow-dimension) ^ 2 + var(--o-ui-tooltip-arrow-dimension) ^ 2) = 14.142135623730951. Since calc doesn't
+       allow complex calculation like this, we pre-compute it in --o-ui-tooltip-lozenge-dimension
+    */
+    --o-ui-tooltip-lozenge-dimension: 14px;
+    --o-ui-tooltip-spacing-with-trigger: var(--o-ui-sp-3);
+}
+
 .o-ui-tooltip {
     background-color: var(--o-ui-bg-alias-surface);
     border-radius: var(--o-ui-br-3);
@@ -8,18 +21,104 @@
     overflow-wrap: break-word;
 }
 
-/* We need a .o-ui-tooltip-content class */
+.o-ui-tooltip-arrow,
+.o-ui-tooltip-arrow::before {
+    position: absolute;
+    width: var(--o-ui-tooltip-arrow-dimension);
+    height: var(--o-ui-tooltip-arrow-dimension);
+    z-index: 1;
+}
+
+.o-ui-tooltip-arrow::before {
+    content: "";
+    transform: rotate(45deg);
+    background-color: var(--o-ui-bg-alias-surface);
+    box-shadow: var(--o-ui-bs-alias-floating);
+}
+
+.o-ui-tooltip-arrow::after {
+    content: "";
+    width: 20px;
+    height: 10px;
+    background-color: var(--o-ui-bg-alias-surface);
+    position: absolute;
+    top: calc(var(--o-ui-tooltip-arrow-dimension) / 2);
+    left: calc(-1 * var(--o-ui-tooltip-arrow-dimension) / 2);
+    z-index: 10;
+}
+
 /* LEFT ICON */
-.o-ui-tooltip .o-ui-icon {
+.o-ui-tooltip-wrapper .o-ui-icon {
     margin-right: var(--o-ui-sp-1);
 }
 
 /* RIGHT ICON */
-.o-ui-tooltip .o-ui-text + .o-ui-icon {
+.o-ui-tooltip-wrapper .o-ui-text + .o-ui-icon {
     margin-left: var(--o-ui-sp-1);
 }
 
 /* DISABLED WRAPPER */
 .o-ui-tooltip-disabled-wrapper {
     display: inline-block;
+}
+
+/* POSITION */
+.o-ui-overlay[data-popper-placement^="top"] .o-ui-tooltip-wrapper {
+    padding-bottom: var(--o-ui-tooltip-spacing-with-trigger);
+}
+
+.o-ui-overlay[data-popper-placement^="bottom"] .o-ui-tooltip-wrapper {
+    padding-top: var(--o-ui-tooltip-spacing-with-trigger);
+}
+
+.o-ui-overlay[data-popper-placement^="left"] .o-ui-tooltip-wrapper {
+    padding-right: var(--o-ui-tooltip-spacing-with-trigger);
+}
+
+.o-ui-overlay[data-popper-placement^="right"] .o-ui-tooltip-wrapper {
+    padding-left: var(--o-ui-tooltip-spacing-with-trigger);
+}
+
+/* ARROW  */
+.o-ui-overlay[data-popper-placement^="top"] .o-ui-tooltip-arrow {
+    bottom: calc(var(--o-ui-tooltip-lozenge-dimension) / 2);
+}
+
+.o-ui-overlay[data-popper-placement^="bottom"] .o-ui-tooltip-arrow {
+    top: calc(var(--o-ui-tooltip-lozenge-dimension) / 2);
+}
+
+.o-ui-overlay[data-popper-placement^="left"] .o-ui-tooltip-arrow {
+    right: calc(var(--o-ui-tooltip-lozenge-dimension) / 2);
+}
+
+.o-ui-overlay[data-popper-placement^="right"] .o-ui-tooltip-arrow {
+    left: calc(var(--o-ui-tooltip-lozenge-dimension) / 2);
+}
+
+/* ARROW | BORDER */
+/* BOTTOM ARROW */
+.o-ui-overlay[data-popper-placement^="bottom"] .o-ui-tooltip-arrow::after {
+    top: calc(var(--o-ui-tooltip-arrow-dimension) / 2);
+}
+
+/* TOP ARROW */
+.o-ui-overlay[data-popper-placement^="top"] .o-ui-tooltip-arrow::after {
+    top: calc(-1 * (var(--o-ui-tooltip-arrow-dimension) / 2));
+}
+
+/* RIGHT ARROW */
+.o-ui-overlay[data-popper-placement^="right"] .o-ui-tooltip-arrow::after {
+    width: 10px;
+    height: 20px;
+    left: calc(var(--o-ui-tooltip-arrow-dimension) / 2);
+    top: calc(-1 * (var(--o-ui-tooltip-arrow-dimension) / 2));
+}
+
+/* LEFT ARROW */
+.o-ui-overlay[data-popper-placement^="left"] .o-ui-tooltip-arrow::after {
+    width: 10px;
+    height: 20px;
+    left: calc(-1 * (var(--o-ui-tooltip-arrow-dimension) / 2));
+    top: calc(-1 * (var(--o-ui-tooltip-arrow-dimension) / 2));
 }

--- a/packages/components/src/tooltip/src/Tooltip.tsx
+++ b/packages/components/src/tooltip/src/Tooltip.tsx
@@ -1,13 +1,14 @@
-import { ComponentProps, ReactNode, SyntheticEvent, forwardRef } from "react";
+import { ComponentProps, ReactNode, SyntheticEvent, forwardRef, RefObject } from "react";
 import { InternalProps, OmitInternalProps, StyledComponentProps, mergeProps, useEventCallback, useFocusScope, useMergedRefs } from "../../shared";
 
 import { Text } from "../../typography";
+import { Div } from "../../html";
 import { useOverlayLightDismiss } from "../../overlay";
 import { useTooltipTriggerContext } from "./TooltipTriggerContext";
 
 const DefaultElement = "div";
-
 export interface InnerTooltipProps extends InternalProps, StyledComponentProps<typeof DefaultElement> {
+    arrowRef?: RefObject<HTMLDivElement>;
     /**
      * React children.
      */
@@ -17,6 +18,7 @@ export interface InnerTooltipProps extends InternalProps, StyledComponentProps<t
 export function InnerTooltip({
     as = DefaultElement,
     children,
+    arrowRef,
     forwardedRef,
     ...rest
 }: InnerTooltipProps) {
@@ -41,20 +43,27 @@ export function InnerTooltip({
     });
 
     return (
-        <Text
+        <Div
             {...mergeProps(
                 rest,
                 {
                     as,
-                    className: "o-ui-tooltip",
+                    className: "o-ui-tooltip-wrapper",
                     ref: tooltipRef,
                     role: "tooltip"
                 },
                 overlayDismissProps
             )}
         >
-            {children}
-        </Text>
+            <Div className="o-ui-tooltip">
+                <Text>{children}</Text>
+            </Div>
+            <Div
+                className="o-ui-tooltip-arrow"
+                ref={arrowRef}
+                zIndex={100}
+            />
+        </Div>
     );
 }
 

--- a/packages/components/src/tooltip/src/TooltipTrigger.tsx
+++ b/packages/components/src/tooltip/src/TooltipTrigger.tsx
@@ -12,8 +12,8 @@ import {
     useId,
     useMergedRefs
 } from "../../shared";
-import { Overlay, OverlayArrow, OverlayPositionProp, isTargetParent, useOverlayPosition, useOverlayTrigger } from "../../overlay";
-import { useResponsiveValue, useThemeContext } from "../../styling";
+import { Overlay, OverlayPositionProp, isTargetParent, useOverlayPosition, useOverlayTrigger } from "../../overlay";
+import { useResponsiveValue } from "../../styling";
 
 import { Div } from "../../html";
 import { TooltipTriggerContext } from "./TooltipTriggerContext";
@@ -93,8 +93,6 @@ export function InnerTooltipTrigger({
 }: InnerTooltipTriggerProps) {
     const positionValue = useResponsiveValue(positionProp);
 
-    const { themeAccessor } = useThemeContext();
-
     const [isOpen, setIsOpen] = useControllableState(open, defaultOpen, false);
 
     const updateIsOpen = useCallback((event: SyntheticEvent, newValue: boolean) => {
@@ -159,6 +157,7 @@ export function InnerTooltipTrigger({
     ));
 
     const tooltipMarkup = augmentElement(tooltip, {
+        arrowRef,
         id: tooltipId
     });
 
@@ -175,7 +174,6 @@ export function InnerTooltipTrigger({
                     rest,
                     {
                         as,
-                        borderOffset: themeAccessor.getSpace(3),
                         ref: overlayRef,
                         show: isOpen,
                         zIndex
@@ -183,10 +181,6 @@ export function InnerTooltipTrigger({
                 )}
             >
                 {tooltipMarkup}
-                <OverlayArrow
-                    ref={arrowRef}
-                    zIndex={zIndex + 100}
-                />
             </Overlay>
         </TooltipTriggerContext.Provider>
     );


### PR DESCRIPTION

## Summary

Fix for issue https://github.com/gsoft-inc/sg-orbit/issues/1141

## Description of the issue

Here is 3 scenario of how the tooltip works before the fix

### Scenario 1 (works): 
- MouseEnter on trigger -> Tooltip shows
- MouseLeave on Trigger  -> MouseEnter on white background -> Tooltip disappear because of the event handlers on the trigger. 
![image](https://user-images.githubusercontent.com/38871812/220200994-397354be-3dc3-4e3d-82d7-8f8f50ded6db.png)


### Scenario 2 (works):
- MouseEnter on trigger -> Tooltip shows
- MouseLeave on trigger ->  MouseEnter Overlay -> Trigger's Event handler ignore the mouseLeave because it's on the overlay. and that is allowed 
- MouseEnter on Tooltip -> Tooltip stays open
- MouseLeave Tooltip -> Tooltip closes because of the event handlers on the tooltip
![image](https://user-images.githubusercontent.com/38871812/220201120-044c00d0-9bb8-4057-a6f5-f53b9d42d477.png)

### Scenario 3 (the issue):
- MouseEnter on trigger -> Tooltip shows
- MouseLeave on Trigger -> MouseEnter on Overlay -> Trigger's Event handler ignore the mouseLeave because it's on the overlay. and that is allowed 
- MouseLeave Overlay -> MouseEnter on white background -> since the mouse never went in the tooltip, the popup stays open because nobody listen to overlay mouseLeave. The bug is here
![image](https://user-images.githubusercontent.com/38871812/220201294-52ed8dcd-5d0d-4d46-9d20-7a5a3fd8d7c6.png)

## What I did

Instead of adding spacing in the overlay and that the overlay adds an arrow, I've move spacing/arrow logic in the tooltip and the popover. This allows better control over how to position and handle the arrow 

