### PR TITLE
Tooltip now closes properly when hovering the overlay without hovering the tooltip

### DIFF
--- a/packages/components/src/tooltip/src/Tooltip.tsx
+++ b/packages/components/src/tooltip/src/Tooltip.tsx
@@ -1,9 +1,7 @@
-import { ComponentProps, ReactNode, SyntheticEvent, forwardRef } from "react";
-import { InternalProps, OmitInternalProps, StyledComponentProps, mergeProps, useEventCallback, useFocusScope, useMergedRefs } from "../../shared";
+import { ComponentProps, ReactNode, forwardRef } from "react";
+import { InternalProps, OmitInternalProps, StyledComponentProps, mergeProps } from "../../shared";
 
 import { Text } from "../../typography";
-import { useOverlayLightDismiss } from "../../overlay";
-import { useTooltipTriggerContext } from "./TooltipTriggerContext";
 
 const DefaultElement = "div";
 

--- a/packages/components/src/tooltip/src/Tooltip.tsx
+++ b/packages/components/src/tooltip/src/Tooltip.tsx
@@ -20,26 +20,6 @@ export function InnerTooltip({
     forwardedRef,
     ...rest
 }: InnerTooltipProps) {
-    const { close } = useTooltipTriggerContext();
-
-    const [focusScope, setFocusRef] = useFocusScope();
-
-    const tooltipRef = useMergedRefs(forwardedRef, setFocusRef);
-
-    const overlayDismissProps = useOverlayLightDismiss(focusScope, {
-        hideOnEscape: true,
-        hideOnLeave: true,
-        hideOnOutsideClick: false,
-        onHide: useEventCallback((event: SyntheticEvent) => {
-            close(event);
-            // Ignore events related to the trigger.
-            // if (!isTargetParent(event.target, triggerRef) && (event as FocusEvent).relatedTarget !== triggerRef.current) {
-            //     close(event);
-            // }
-        }),
-        trigger: "hover"
-    });
-
     return (
         <Text
             {...mergeProps(
@@ -47,10 +27,9 @@ export function InnerTooltip({
                 {
                     as,
                     className: "o-ui-tooltip",
-                    ref: tooltipRef,
+                    ref: forwardedRef,
                     role: "tooltip"
-                },
-                overlayDismissProps
+                }
             )}
         >
             {children}

--- a/packages/components/src/tooltip/src/TooltipTrigger.tsx
+++ b/packages/components/src/tooltip/src/TooltipTrigger.tsx
@@ -166,11 +166,10 @@ export function InnerTooltipTrigger({
         hideOnLeave: true,
         hideOnOutsideClick: false,
         onHide: useEventCallback((event: SyntheticEvent) => {
-            close(event);
             // Ignore events related to the trigger.
-            // if (!isTargetParent(event.target, triggerRef) && (event as FocusEvent).relatedTarget !== triggerRef.current) {
-            //     close(event);
-            // }
+            if ((event as FocusEvent).relatedTarget !== triggerRef.current) {
+                close(event);
+            }
         }),
         trigger: "hover"
     });

--- a/packages/components/src/tooltip/src/TooltipTrigger.tsx
+++ b/packages/components/src/tooltip/src/TooltipTrigger.tsx
@@ -10,9 +10,10 @@ import {
     useControllableState,
     useEventCallback,
     useId,
-    useMergedRefs
+    useMergedRefs,
+    useFocusScope
 } from "../../shared";
-import { Overlay, OverlayArrow, OverlayPositionProp, isTargetParent, useOverlayPosition, useOverlayTrigger } from "../../overlay";
+import { Overlay, OverlayArrow, OverlayPositionProp, isTargetParent, useOverlayPosition, useOverlayTrigger, useOverlayLightDismiss } from "../../overlay";
 import { useResponsiveValue, useThemeContext } from "../../styling";
 
 import { Div } from "../../html";
@@ -119,7 +120,9 @@ export function InnerTooltipTrigger({
         position: positionValue
     });
 
-    const overlayRef = useMergedRefs(overlayPositionRef, forwardedRef);
+    const [focusScope, setFocusRef] = useFocusScope();
+
+    const overlayRef = useMergedRefs(overlayPositionRef, forwardedRef, setFocusRef);
 
     const triggerProps = useOverlayTrigger(isOpen, {
         hideOnLeave: true,
@@ -158,8 +161,23 @@ export function InnerTooltipTrigger({
         }
     ));
 
+    const overlayDismissProps = useOverlayLightDismiss(focusScope, {
+        hideOnEscape: true,
+        hideOnLeave: true,
+        hideOnOutsideClick: false,
+        onHide: useEventCallback((event: SyntheticEvent) => {
+            close(event);
+            // Ignore events related to the trigger.
+            // if (!isTargetParent(event.target, triggerRef) && (event as FocusEvent).relatedTarget !== triggerRef.current) {
+            //     close(event);
+            // }
+        }),
+        trigger: "hover"
+    });
+
     const tooltipMarkup = augmentElement(tooltip, {
-        id: tooltipId
+        id: tooltipId,
+        ref: setFocusRef
     });
 
     return (
@@ -179,7 +197,8 @@ export function InnerTooltipTrigger({
                         ref: overlayRef,
                         show: isOpen,
                         zIndex
-                    }
+                    },
+                    overlayDismissProps
                 )}
             >
                 {tooltipMarkup}

--- a/packages/components/src/tooltip/tests/jest/TooltipTrigger.test.tsx
+++ b/packages/components/src/tooltip/tests/jest/TooltipTrigger.test.tsx
@@ -62,17 +62,11 @@ test("when hovering the overlay arrow, close on overlay leave", async () => {
 
     expect(await screen.findByRole("tooltip")).toBeInTheDocument();
 
-    // fireEvent.mouseLeave() since we need to specify the relatedTarget.
-    fireEvent.mouseLeave(screen.getByTestId("trigger"), {
-        relatedTarget: getOverlayArrow(screen.getByTestId("overlay"))
-    });
+    await userEvent.hover(getOverlayArrow(screen.getByTestId("overlay")));
 
     expect(await screen.findByRole("tooltip")).toBeInTheDocument();
 
-    // fireEvent.mouseLeave() since we need to specify the relatedTarget.
-    fireEvent.mouseLeave(getOverlayArrow(screen.getByTestId("overlay")), {
-        relatedTarget:document.body
-    });
+    await userEvent.unhover(getOverlayArrow(screen.getByTestId("overlay")));
 
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
 });
@@ -89,17 +83,11 @@ test("when hovering the tooltip, do not close if hovering the trigger", async ()
 
     expect(await screen.findByRole("tooltip")).toBeInTheDocument();
 
-    // fireEvent.mouseLeave() since we need to specify the relatedTarget.
-    fireEvent.mouseLeave(screen.getByTestId("trigger"), {
-        relatedTarget: screen.getByRole("tooltip")
-    });
+    await userEvent.hover(screen.getByRole("tooltip"));
 
     expect(await screen.findByRole("tooltip")).toBeInTheDocument();
 
-    // fireEvent.mouseLeave() since we need to specify the relatedTarget.
-    fireEvent.mouseLeave(screen.getByRole("tooltip"), {
-        relatedTarget: screen.getByTestId("trigger")
-    });
+    await userEvent.hover(screen.getByTestId("trigger"));
 
     expect(screen.getByRole("tooltip")).toBeInTheDocument();
 });

--- a/packages/components/src/tooltip/tests/jest/TooltipTrigger.test.tsx
+++ b/packages/components/src/tooltip/tests/jest/TooltipTrigger.test.tsx
@@ -46,6 +46,64 @@ test("when the trigger is disabled, close on trigger leave", async () => {
     await waitFor(() => expect(screen.queryByTestId("tooltip")).not.toBeInTheDocument());
 });
 
+function getOverlayArrow(element: HTMLElement) {
+    return element.querySelector(".o-ui-overlay-arrow");
+}
+
+test("when hovering the overlay arrow, close on overlay leave", async () => {
+    renderWithTheme(
+        <TooltipTrigger data-testid="overlay">
+            <Button data-testid="trigger">Trigger</Button>
+            <Tooltip>Content</Tooltip>
+        </TooltipTrigger>
+    );
+
+    await userEvent.hover(screen.getByTestId("trigger"));
+
+    expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+    // fireEvent.mouseLeave() since we need to specify the relatedTarget.
+    fireEvent.mouseLeave(screen.getByTestId("trigger"), {
+        relatedTarget: getOverlayArrow(screen.getByTestId("overlay"))
+    });
+
+    expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+    // fireEvent.mouseLeave() since we need to specify the relatedTarget.
+    fireEvent.mouseLeave(getOverlayArrow(screen.getByTestId("overlay")), {
+        relatedTarget:document.body
+    });
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+});
+
+test("when hovering the tooltip, do not close if hovering the trigger", async () => {
+    renderWithTheme(
+        <TooltipTrigger>
+            <Button data-testid="trigger">Trigger</Button>
+            <Tooltip>Content</Tooltip>
+        </TooltipTrigger>
+    );
+
+    await userEvent.hover(screen.getByTestId("trigger"));
+
+    expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+    // fireEvent.mouseLeave() since we need to specify the relatedTarget.
+    fireEvent.mouseLeave(screen.getByTestId("trigger"), {
+        relatedTarget: screen.getByRole("tooltip")
+    });
+
+    expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+    // fireEvent.mouseLeave() since we need to specify the relatedTarget.
+    fireEvent.mouseLeave(screen.getByRole("tooltip"), {
+        relatedTarget: screen.getByTestId("trigger")
+    });
+
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+});
+
 // ***** Aria *****
 
 test("when an id is provided for the tooltip, it is used as the tooltip id", async () => {
@@ -179,4 +237,3 @@ test("set ref once", async () => {
 
     await waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
 });
-


### PR DESCRIPTION
## Summary

Fix for issue https://github.com/gsoft-inc/sg-orbit/issues/1141

## Description of the issue

Here is 3 scenario of how the tooltip works before the fix

### Scenario 1 (works): 
- MouseEnter on trigger -> Tooltip shows
- MouseLeave on Trigger  -> MouseEnter on white background -> Tooltip disappear because of the event handlers on the trigger. 
![image](https://user-images.githubusercontent.com/38871812/220200994-397354be-3dc3-4e3d-82d7-8f8f50ded6db.png)


### Scenario 2 (works):
- MouseEnter on trigger -> Tooltip shows
- MouseLeave on trigger ->  MouseEnter Overlay -> Trigger's Event handler ignore the mouseLeave because it's on the overlay. and that is allowed 
- MouseEnter on Tooltip -> Tooltip stays open
- MouseLeave Tooltip -> Tooltip closes because of the event handlers on the tooltip
![image](https://user-images.githubusercontent.com/38871812/220201120-044c00d0-9bb8-4057-a6f5-f53b9d42d477.png)

### Scenario 3 (the issue):
- MouseEnter on trigger -> Tooltip shows
- MouseLeave on Trigger -> MouseEnter on Overlay -> Trigger's Event handler ignore the mouseLeave because it's on the overlay. and that is allowed 
- MouseLeave Overlay -> MouseEnter on white background -> since the mouse never went in the tooltip, the popup stays open because nobody listen to overlay mouseLeave. The bug is here
![image](https://user-images.githubusercontent.com/38871812/220201294-52ed8dcd-5d0d-4d46-9d20-7a5a3fd8d7c6.png)

## What I did

Instead of handling the dismiss inside the tooltip, i'm handling it in the trigger
