### PR TITLE
added html attribute to prevent dashlane from adding its icon on date…

### DIFF
--- a/packages/components/src/date-input/src/DateInput.tsx
+++ b/packages/components/src/date-input/src/DateInput.tsx
@@ -200,6 +200,7 @@ export function InnerDateInput({
             {...mergeProps(
                 rest,
                 {
+                    "data-form-type" : "other",
                     onDateChange: handleDateChange,
                     placeholder,
                     ref: inputRef,

--- a/packages/components/src/date-input/src/DateRangeInput.tsx
+++ b/packages/components/src/date-input/src/DateRangeInput.tsx
@@ -153,6 +153,7 @@ const DateInput = forwardRef<HTMLInputElement, any>(({
                     "aria-invalid": validationState === "invalid" ? true : undefined,
                     "aria-required": required ? true : undefined,
                     className: "o-ui-date-range-input-date-input",
+                    "data-form-type" : "other",
                     disabled,
                     placeholder,
                     readOnly,


### PR DESCRIPTION
Issue: 

DatePicker Input is not wide enough clashing with password managers #953 

## Summary

Dashlane was adding it's icon on date inputs pretending it was a birth date input!

## What I did

Added a data attribute to make Dashlane behave.

## How to test

Visit the date input / date range input doc page with Dashlane installed.