### PR TITLE
Feature/icon design updates

### DIFF
--- a/packages/components/src/accordion/src/Accordion.css
+++ b/packages/components/src/accordion/src/Accordion.css
@@ -82,13 +82,8 @@
     padding-left: var(--o-ui-sp-4);
 }
 
-.o-ui-accordion-icon {
-    margin-left: 0.125rem;
-    margin-right: 0.125rem;
-}
-
 .o-ui-accordion-icon + .o-ui-accordion-title {
-    margin-left: var(--o-ui-sp-1);
+    margin-left: var(--o-ui-sp-2);
 }
 
 /* PANEL */

--- a/packages/components/src/checkbox/src/Checkbox.css
+++ b/packages/components/src/checkbox/src/Checkbox.css
@@ -104,13 +104,13 @@
 
 /* CONTENT | ICON */
 .o-ui-checkbox-icon {
-    margin-left: calc(var(--o-ui-sp-1) + 0.125rem);
+    margin-left: var(--o-ui-sp-1);
 }
 
 /* CONTENT | ICON | REVERSE */
 .o-ui-checkbox-reverse .o-ui-checkbox-icon {
     margin-left: 0;
-    margin-right: calc(var(--o-ui-sp-1) + 0.125rem);
+    margin-right: var(--o-ui-sp-1);
 }
 
 /* REVERSE */

--- a/packages/components/src/listbox/src/Listbox.css
+++ b/packages/components/src/listbox/src/Listbox.css
@@ -71,7 +71,7 @@ IMPORTANT: The Listbox component hardcoded a few CSS values to enable dynamic sc
     mask-size: contain;
     background-color: var(--o-ui-bg-alias-accent);
     position: absolute;
-    right: 0.875rem;
+    right: calc((var(--o-ui-sp-8) - var(--o-ui-listbox-option-checkmark-size)) / 2);
 }
 
 /* OPTION | STATE | DISABLED */
@@ -132,7 +132,6 @@ IMPORTANT: The Listbox component hardcoded a few CSS values to enable dynamic sc
 /* OPTION | ICONS | START ICON */
 .o-ui-listbox-option-start-icon {
     margin-right: calc(var(--o-ui-sp-1) + 0.125rem);
-    margin-left: 0.125rem;
     grid-area: aside;
 }
 
@@ -144,7 +143,7 @@ IMPORTANT: The Listbox component hardcoded a few CSS values to enable dynamic sc
 
 /* OPTION | ICONS | END ICON */
 .o-ui-listbox-option-end-icon {
-    margin-left: calc(var(--o-ui-sp-1) + 0.125rem);
+    margin-left: calc(var(--o-ui-sp-2) + 0.125rem);
 }
 
 /* SECTION */

--- a/packages/components/src/message/src/Message.css
+++ b/packages/components/src/message/src/Message.css
@@ -2,7 +2,7 @@
     display: flex;
     align-items: flex-start;
     flex-wrap: wrap;
-    padding: var(--o-ui-sp-2) var(--o-ui-sp-3) var(--o-ui-sp-2) var(--o-ui-sp-9);
+    padding: var(--o-ui-sp-2) var(--o-ui-sp-3) var(--o-ui-sp-2) var(--o-ui-sp-8);
     width: 100%;
     height: max-content;
     border-radius: var(--o-ui-br-3);

--- a/packages/components/src/radio/src/Radio.css
+++ b/packages/components/src/radio/src/Radio.css
@@ -54,13 +54,13 @@
 
 /* CONTENT | ICON */
 .o-ui-radio-icon {
-    margin-left: calc(var(--o-ui-sp-2) + 0.125rem);
+    margin-left: var(--o-ui-sp-1);
 }
 
 /* CONTENT | ICON | REVERSE */
 .o-ui-radio-reverse .o-ui-radio-icon {
     margin-left: 0;
-    margin-right: calc(var(--o-ui-sp-2) + 0.125rem);
+    margin-right: var(--o-ui-sp-1);
 }
 
 /* CONTENT | COUNTER */

--- a/packages/components/src/switch/src/Switch.css
+++ b/packages/components/src/switch/src/Switch.css
@@ -47,13 +47,13 @@
 
 /* ICON */
 .o-ui-switch .o-ui-switch-icon {
-    margin-left: calc(var(--o-ui-sp-1) + 0.125rem);
+    margin-left: var(--o-ui-sp1);
 }
 
 /* ICON | REVERSE */
 .o-ui-switch-reverse .o-ui-switch-icon {
     margin-left: 0;
-    margin-right: calc(var(--o-ui-sp-1) + 0.125rem);
+    margin-right: var(--o-ui-sp-1);
 }
 
 /* REVERSE */

--- a/yarn.lock
+++ b/yarn.lock
@@ -9133,9 +9133,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.17, electron-to-chromium@^1.4.284:
-  version "1.4.312"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.312.tgz#e70a5b46252814ffc576b2c29032e1a559b9ad53"
-  integrity sha512-e7g+PzxzkbiCD1aNhdj+Tx3TLlfrQF/Lf+LAaUdoLvB1kCxf9wJimqXdWEqnoiYjFtxIR1hGBmoHsBIcCBNOMA==
+  version "1.4.314"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.314.tgz#33e4ad7a2ca2ddbe2e113874cc0c0e2a00cb46bf"
+  integrity sha512-+3RmNVx9hZLlc0gW//4yep0K5SYKmIvB5DXg1Yg6varsuAHlHwTeqeygfS8DWwLCsNOWrgj+p9qgM5WYjw1lXQ==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Issue: 

## Summary

Some spacing issues had to be solved post icon rework.

## What I did

## Accordion
- removed margin left on icon
- Spacing between icon and title is now 8px

## Listbox

- Listbox checkmark position is now 10px from the right
- Icon has no margin left anymore.
- endIcon has 10px margin on the left

## Message

- Padding left is now 40px - icon is positioned inside the padding at 12px

## Radio

- icon has now a 4px margin from the text

## Checkbox

- icon has now a 4px margin from the text

## Switch

- icon has now a 4px margin from the text