### PR TITLE
Modified Changeset Workflow so it doesn't get cancelled

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches: ["master"]
 
-concurrency:
-    group: ${{ github.ref }}
-    cancel-in-progress: true
-
 jobs:
   release:
     name: Release

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,9 +3,7 @@
 
 name: Chromatic
 
-on:
-    schedule:
-        - cron:  '0 0 * * 1-5'    
+on:  
     pull_request:
         branches-ignore:
           - changeset-release/*


### PR DESCRIPTION
## Summary

- Changeset workflow was getting cancelled by the CI because of the concurrency group.
- Also removed the nightly chromatic build since the action does not support it and it doesn't seem necessary
