### PR TITLE
input and textarea inherits font size and family from parent / unifie…

### DIFF
--- a/.changeset/yellow-goats-hunt.md
+++ b/.changeset/yellow-goats-hunt.md
@@ -1,0 +1,5 @@
+---
+"@orbit-ui/components": minor
+---
+
+text inputs and textarea inherits the app font-family and font-size

--- a/packages/components/src/input/src/Input.css
+++ b/packages/components/src/input/src/Input.css
@@ -19,6 +19,8 @@
 
 .o-ui-input input {
     -webkit-appearance: none;
+    font-family: inherit;
+    font-size: inherit;
     outline: transparent;
     border: none;
     width: 100%;

--- a/packages/components/src/text-area/src/TextArea.css
+++ b/packages/components/src/text-area/src/TextArea.css
@@ -1,3 +1,7 @@
+.o-ui-text-area {
+    font-size: var(--o-ui-fs-3);
+}
+
 .o-ui-text-area textarea {
     --o-ui-textarea-padding: var(--o-ui-sp-3);
     resize: vertical;
@@ -6,6 +10,8 @@
     padding: var(--o-ui-sp-2) var(--o-ui-textarea-padding);
     min-height: var(--o-ui-sz-11);
     color: inherit;
+    font-family: inherit;
+    font-size: inherit;
 }
 
 /* TRANSPARENT */


### PR DESCRIPTION
Issue: 

## Summary

Inputs and Textareas were not inheriting our defaulf font size and familyi

## What I did

Input and textarea now inherits whatever font size and font family is set. While fixing this it has been noted that the textarea font size was inherited from the root. This has been fixed.
