### PR TITLE
link orbit and components together so their version is synced

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [],
+  "linked": [["@sharegate/orbit-ui", "@orbit-ui/components"]],
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch"


### PR DESCRIPTION
## Summary

At the moment, when modifying the components project, the bundle is incremented using a patch version, instead of following the same "bump severity". 

With our current setup, the bundle basically ships the components project + ~10 lines of css from the @orbit-ui/css projects. I believe one day that we might move away from having a bundle package.

Until then, I'll link the versions of the 2 packages so every time the components packages gets updated, the bundle receives the same update. The only possible side effect i see is that if we ever modify one of the 10 lines of css from the @orbit-ui/css and the components are unaffected by the changes, we'll still bump the @orbit-ui/components packages. This is something i'm ok with. 