### PR TITLE
Only major changes of orbit will cause an update of experimental

### DIFF
--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -25,12 +25,12 @@
         "clean": "rimraf dist tsconfig.build.tsbuildinfo"
     },
     "peerDependencies": {
-        "@sharegate/orbit-ui": ">=34.2.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@sharegate/orbit-ui": "^34",
+        "react": "^18",
+        "react-dom": "^18"
     },
     "devDependencies": {
-        "@sharegate/orbit-ui": "34.2.0"
+        "@sharegate/orbit-ui": "^34"
     },
     "gitHead": "f8b5019bdc53f68abe27e931387aeec7f0747d85"
 }


### PR DESCRIPTION
## Summary

Everytime `sharegate/orbit-ui` receives an update, the `orbit-ui/experimental` gets bumped. Its unecessary, so now only major version will trigger a version bump
