### PR TITLE
Toggling experimental feature of changeset

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,8 @@
   "linked": [["@sharegate/orbit-ui", "@orbit-ui/components"]],
   "access": "public",
   "baseBranch": "master",
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/happy-bananas-film.md
+++ b/.changeset/happy-bananas-film.md
@@ -1,0 +1,5 @@
+---
+"@orbit-ui/experimental": patch
+---
+
+Fix the peer dependency version again

--- a/packages/experimental/package.json
+++ b/packages/experimental/package.json
@@ -25,12 +25,12 @@
         "clean": "rimraf dist tsconfig.build.tsbuildinfo"
     },
     "peerDependencies": {
-        "@sharegate/orbit-ui": "^34",
+        "@sharegate/orbit-ui": "^34.0.0",
         "react": "^18",
         "react-dom": "^18"
     },
     "devDependencies": {
-        "@sharegate/orbit-ui": "^34"
+        "@sharegate/orbit-ui": "^34.0.0"
     },
     "gitHead": "f8b5019bdc53f68abe27e931387aeec7f0747d85"
 }


### PR DESCRIPTION
## Summary

Toggling the experimental feature to prevent releases of experimental component at every orbit-ui/component  releases .
Had to fix the release version right away to not trigger unecessary changes later