### PR TITLE
Tabs were not inheriting our base font-family

### DIFF
--- a/.changeset/nine-elephants-deny.md
+++ b/.changeset/nine-elephants-deny.md
@@ -1,0 +1,5 @@
+---
+"@orbit-ui/components": patch
+---
+
+fixed an issue where tabs triggers would not inherit the body font family

--- a/packages/components/src/tabs/src/Tabs.css
+++ b/packages/components/src/tabs/src/Tabs.css
@@ -108,6 +108,7 @@
     min-height: var(--o-ui-sz-7);
     color: var(--o-ui-text-alias-secondary);
     position: relative;
+    font-family: inherit;
 }
 
 /* View https://css-tricks.com/slightly-careful-sub-elements-clickable-things */


### PR DESCRIPTION
Issue: 

## Summary

Tab Trigger were not inheriting our base font-family.  Tab buttons use Arial font #1196

## What I did

The tab trigger now inherits the font-family.

## How to test

/?path=/docs/tabs--default-story Inspect a tab trigger.