### PR TITLE
added sample for loader and text change for spinner

### DIFF
--- a/packages/components/src/loader/docs/Loader.stories.mdx
+++ b/packages/components/src/loader/docs/Loader.stories.mdx
@@ -1,6 +1,7 @@
 import { ArgsTable, Meta, Story } from "@storybook/addon-docs";
 import { ComponentInfo, Preview, Tagline } from "@stories/components";
 import { InnerLoader, Loader } from "@components/loader";
+import { Stack } from "@components/layout";
 
 <Meta
     title="Components/Loader"
@@ -58,7 +59,10 @@ By settings `delay` to `true`, the loader will appear after 300ms. You can also 
 
 <Preview>
     <Story name="delay">
-        <Loader delay aria-label="Loading..."/>
+        <Stack>
+            <Loader delay aria-label="Loading..."/>
+            <Loader delay={800} aria-label="Loading..."/>
+        </Stack>
     </Story>
 </Preview>
 

--- a/packages/components/src/spinner/docs/Spinner.stories.mdx
+++ b/packages/components/src/spinner/docs/Spinner.stories.mdx
@@ -74,7 +74,7 @@ A spinner can have a label.
 </Preview>
 
 
-### Over Background
+### Over background
 
 You can change a spinner style when over a background by setting a color property on the spinner.
 


### PR DESCRIPTION
Issue: 

## Summary

Loader doc had no samples for a custom delay. Spinner Over background example was not following our norm.

## What I did

Fixed these.
