### PR TITLE
fix: missing aria-label on loading IconButton

### DIFF
--- a/.changeset/rare-eyes-fly.md
+++ b/.changeset/rare-eyes-fly.md
@@ -1,0 +1,5 @@
+---
+"@orbit-ui/components": patch
+---
+
+Fix missing aria-label on IconButton's Spinner when loading is true

--- a/packages/components/src/button/src/IconButton.tsx
+++ b/packages/components/src/button/src/IconButton.tsx
@@ -128,6 +128,7 @@ export function InnerIconButton(props: InnerIconButtonProps) {
 
     const loadingMarkup = loading && (
         <Spinner
+            aria-label="Loading..."
             className="o-ui-button-spinner"
             color={variant === "primary" ? "alias-static-white" : undefined}
             role="presentation"

--- a/packages/components/src/button/tests/jest/IconButton.test.tsx
+++ b/packages/components/src/button/tests/jest/IconButton.test.tsx
@@ -80,7 +80,6 @@ test("when loading is true, the spinner should have an aria-label", async () => 
         <IconButton
             loading
             aria-label="Add"
-            data-testid="button"
         >
             <AddMajorIcon />
         </IconButton>

--- a/packages/components/src/button/tests/jest/IconButton.test.tsx
+++ b/packages/components/src/button/tests/jest/IconButton.test.tsx
@@ -73,6 +73,24 @@ test("when loading is true, the button should prevent onClick", async () => {
     await waitFor(() => expect(handler).not.toHaveBeenCalled());
 });
 
+// ***** Aria *****
+
+test("when loading is true, the spinner should have an aria-label", async () => {
+    renderWithTheme(
+        <IconButton
+            loading
+            aria-label="Add"
+            data-testid="button"
+        >
+            <AddMajorIcon />
+        </IconButton>
+    );
+
+    const spinner = screen.getByRole("presentation");
+
+    expect(spinner).toHaveAttribute("aria-label");
+});
+
 // ***** Api *****
 
 test("can focus the button with the focus api", async () => {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Fixes #1207  

## Summary

`aria-label` was missing on the spinner when using a loading `IconButton`, which threw a console error.

## What I did

I added an aria-label to the spinner.

## How to test

- Is this testable with Jest or Chromatic screenshots?

Yes, I add a unit test to ensure the spinner has the aria-label attribute set.

- Does this need an update to the documentation?

No
