### PR TITLE
fix: Stale closure preventing tooltip from closing on mouseleave

### DIFF
--- a/.changeset/popular-parrots-kiss.md
+++ b/.changeset/popular-parrots-kiss.md
@@ -1,0 +1,5 @@
+---
+"@orbit-ui/components": patch
+---
+
+Fix tooltip staying open when moving the mouse quickly

--- a/packages/components/src/tooltip/src/TooltipTrigger.tsx
+++ b/packages/components/src/tooltip/src/TooltipTrigger.tsx
@@ -101,9 +101,8 @@ export function InnerTooltipTrigger({
     const updateIsOpen = useCallback((event: SyntheticEvent, newValue: boolean) => {
         // Ideally, we would only update the state if we transition from open
         // to closed and vice-versa, but comparing the current value of
-        // `isOpen` with the `newValue` results in a stale closure issues,
-        // which can result in the tooltip being left open after moving the
-        // cursor away.
+        // `isOpen` with the `newValue` results in a stale closure, which can
+        // result in the tooltip being left open after moving the cursor away.
         setIsOpen(newValue);
 
         if (!isNil(onOpenChange)) {

--- a/packages/components/src/tooltip/src/TooltipTrigger.tsx
+++ b/packages/components/src/tooltip/src/TooltipTrigger.tsx
@@ -99,14 +99,17 @@ export function InnerTooltipTrigger({
     const [isOpen, setIsOpen] = useControllableState(open, defaultOpen, false);
 
     const updateIsOpen = useCallback((event: SyntheticEvent, newValue: boolean) => {
-        if (isOpen !== newValue) {
-            setIsOpen(newValue);
+        // Ideally, we would only update the state if we transition from open
+        // to closed and vice-versa, but comparing the current value of
+        // `isOpen` with the `newValue` results in a stale closure issues,
+        // which can result in the tooltip being left open after moving the
+        // cursor away.
+        setIsOpen(newValue);
 
-            if (!isNil(onOpenChange)) {
-                onOpenChange(event, newValue);
-            }
+        if (!isNil(onOpenChange)) {
+            onOpenChange(event, newValue);
         }
-    }, [onOpenChange, isOpen, setIsOpen]);
+    }, [onOpenChange, setIsOpen]);
 
     const close = useCallback((event: SyntheticEvent) => {
         updateIsOpen(event, false);

--- a/packages/components/src/tooltip/tests/jest/TooltipTrigger.test.tsx
+++ b/packages/components/src/tooltip/tests/jest/TooltipTrigger.test.tsx
@@ -92,6 +92,24 @@ test("when hovering the tooltip, do not close if hovering the trigger", async ()
     expect(screen.getByRole("tooltip")).toBeInTheDocument();
 });
 
+test("when unhovering the tooltip, close tooltip", async () => {
+    renderWithTheme(
+        <TooltipTrigger>
+            <Button data-testid="trigger">Trigger</Button>
+            <Tooltip>Content</Tooltip>
+        </TooltipTrigger>
+    );
+
+    await userEvent.hover(screen.getByTestId("trigger"), { });
+
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    await userEvent.unhover(screen.getByRole("tooltip"));
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+});
+
+
 // ***** Aria *****
 
 test("when an id is provided for the tooltip, it is used as the tooltip id", async () => {


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Closes #1141

## Summary

Seems like tooltips remaining open was related to performance, as it mostly appeared in performance intensive areas like virtualized tables.

My guess was that the issue was caused by calling the `onmouseenter` and `onmouseleave` callbacks in a single render.

My guess seems to have been confirmed after simulating a slow render by adding these lines to the `TriggerTooltip` 

```js
// We simulate a render that takes a least 500ms to happen.
// This gives us enough time to trigger both onmouseenter and onmouseleave events in a single render.
const start = performance.now();
while(performance.now() - 500 < start) {};
```

## What I did

After looking into the code, I noticed that we had an if-statement that looked at the current value of `isOpen` before updating the state. `isOpen` can become stale if `onmouseenter` and `onmouseleave` happen in a single render. I modified the setter function to accept an _updater function_, which always passes the most up-to-date state as the parameter, which fixes the stale closure issue.

## How to test

No idea if we can make a test for this.
