### PR TITLE
fix: Misaligned checkmark background on tile with illustration

### DIFF
--- a/.changeset/selfish-cooks-cross.md
+++ b/.changeset/selfish-cooks-cross.md
@@ -1,0 +1,5 @@
+---
+"@orbit-ui/components": patch
+---
+
+Fix misaligned checkmark background when a tile has an illustration.

--- a/packages/components/src/tile/src/Tile.css
+++ b/packages/components/src/tile/src/Tile.css
@@ -96,26 +96,8 @@
     top: 0.5rem;
     fill: var(--o-ui-bg-alias-accent-faint);
     opacity: 0;
-}
-
-.o-ui-tile-main::before {
-    content: "";
-    opacity: 0;
-    position: absolute;
-    right: 0.5rem;
-    top: 0.5rem;
     border-radius: var(--o-ui-br-4);
-    width: var(--o-ui-sz-3);
-    height: var(--o-ui-sz-3);
-    display: flex;
-    align-items: center;
-    justify-content: center;
     background-color: var(--o-ui-text-alias-accent);
-}
-
-.o-ui-tile[aria-checked="true"] .o-ui-tile-main::before,
-.o-ui-tile[aria-pressed="true"] .o-ui-tile-main::before {
-    opacity: 1;
 }
 
 .o-ui-tile[aria-checked="true"] .o-ui-tile-checkmark,


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Issue: #1226 

## Summary

Fixes this icon:

![image](https://github.com/gsoft-inc/sg-orbit/assets/44372776/a8772e8e-87b3-4291-826d-8ed1c758ea95)

## What I did

Made the background of the checkmark icon an actual background, instead of a `::before` pseudo-element.

## How to test

- Is this testable with Jest or Chromatic screenshots? Yes

- Does this need an update to the documentation? No

If your answer is yes to any of these, please make sure to include it in your PR.
