### PR TITLE
Fix "An input component must either have a 'aria-label' attribute..." error when a <label> is present

### DIFF
--- a/.changeset/forty-cougars-tease.md
+++ b/.changeset/forty-cougars-tease.md
@@ -1,0 +1,5 @@
+---
+"@orbit-ui/components": patch
+---
+
+Remove warning about accessibility on input elements when a label is present

--- a/packages/components/src/number-input/src/NumberInput.tsx
+++ b/packages/components/src/number-input/src/NumberInput.tsx
@@ -1,6 +1,6 @@
 import { AbstractInputProps, adaptInputStylingProps, useInput, useInputIcon, useInputSpinner } from "../../input";
 import { Box, BoxProps } from "../../box";
-import { ChangeEvent, ComponentProps, FocusEvent, FocusEventHandler, MouseEvent, ReactElement, Ref, SyntheticEvent, forwardRef, useCallback, useMemo } from "react";
+import { ChangeEvent, ComponentProps, FocusEvent, FocusEventHandler, MouseEvent, ReactElement, Ref, SyntheticEvent, forwardRef, useCallback, useEffect, useMemo } from "react";
 import { Div, HtmlButton } from "../../html";
 import {
     OmitInternalProps,
@@ -201,10 +201,6 @@ export function InnerNumberInput(props: InnerNumberInputProps) {
         ...rest
     } = adaptInputStylingProps(props, contextualProps);
 
-    if (isNil(ariaLabel) && isNil(ariaLabelledBy) && isNil(placeholder)) {
-        console.error("An input component must either have an \"aria-label\" attribute, an \"aria-labelledby\" attribute or a \"placeholder\" attribute.");
-    }
-
     const fluidValue = useResponsiveValue(fluid);
 
     const [inputValueRef, setInputValue] = useRefState("");
@@ -333,6 +329,14 @@ export function InnerNumberInput(props: InnerNumberInputProps) {
         type: "number",
         validationState,
         value: inputValueRef.current
+    });
+
+    useEffect(() => {
+        const input = inputRef.current;
+
+        if (isNil(ariaLabel) && isNil(ariaLabelledBy) && isNil(placeholder) && isNilOrEmpty(input.labels)) {
+            console.error("An input component must either have a <label> element, a \"aria-label\" attribute, an \"aria-labelledby\" attribute or a \"placeholder\" attribute.");
+        }
     });
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/components/src/number-input/tests/jest/NumberInput.test.tsx
+++ b/packages/components/src/number-input/tests/jest/NumberInput.test.tsx
@@ -1,8 +1,13 @@
 import { Field, Label } from "@components/field";
 import { act, screen, waitFor, renderWithTheme } from "@test-utils";
 import { NumberInput } from "@components/number-input";
+import { Text } from "@components/typography";
 import { createRef } from "react";
 import userEvent from "@testing-library/user-event";
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
 
 // ***** Behaviors *****
 
@@ -574,3 +579,53 @@ test("set ref once", async () => {
 
     await waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
 });
+
+// ***** Accessibility *****
+
+test("logs an error when label is missing", async () => {
+    const spy = jest.spyOn(console, "error");
+
+    renderWithTheme(<NumberInput />);
+
+    expect(spy).toHaveBeenCalled();
+});
+
+test("does not log an error when a label is present", async () => {
+    const spy = jest.spyOn(console, "error");
+
+    renderWithTheme(
+        <Label>
+            Label
+            <NumberInput />
+        </Label>
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+
+    renderWithTheme(
+        <>
+            <Label htmlFor="test">Label</Label>
+            <NumberInput id="test" />
+        </>
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+
+    renderWithTheme(<NumberInput id="test" aria-label="Label" />);
+
+    expect(spy).not.toHaveBeenCalled();
+
+    renderWithTheme(<NumberInput id="test" placeholder="Label" />);
+
+    expect(spy).not.toHaveBeenCalled();
+
+    renderWithTheme(
+        <>
+            <Text id="label">Label</Text>
+            <NumberInput aria-labelledby="label" />
+        </>
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+});
+

--- a/packages/components/src/shared/src/assertions.ts
+++ b/packages/components/src/shared/src/assertions.ts
@@ -15,7 +15,7 @@ export function isNil(value: any): value is null | undefined {
 }
 
 export function isNilOrEmpty(value: any) {
-    return isNil(value) || value === "";
+    return isNil(value) || value.length === 0;
 }
 
 export function isString(value: any): value is string {

--- a/packages/components/src/text-area/src/TextArea.tsx
+++ b/packages/components/src/text-area/src/TextArea.tsx
@@ -1,7 +1,7 @@
 import { AbstractInputProps, adaptInputStylingProps, useInput, useInputButton, useInputHasFocus, useInputSpinner } from "../../input";
 import { Box, BoxProps } from "../../box";
 import { ChangeEvent, ComponentProps, ReactElement, forwardRef, useCallback, useEffect, useMemo, useState } from "react";
-import { OmitInternalProps, cssModule, getBodyElement, isNil, mergeProps, useChainedEventCallback, useControllableState, useIsomorphicLayoutEffect } from "../../shared";
+import { OmitInternalProps, cssModule, getBodyElement, isNil, isNilOrEmpty, mergeProps, useChainedEventCallback, useControllableState, useIsomorphicLayoutEffect } from "../../shared";
 import { ResponsiveProp, useResponsiveValue } from "../../styling";
 import { useFieldInputProps } from "../../field";
 
@@ -139,10 +139,6 @@ export function InnerTextArea(props: InnerTextAreaProps) {
         ...rest
     } = adaptInputStylingProps(props, fieldProps);
 
-    if (isNil(ariaLabel) && isNil(ariaLabelledBy) && isNil(placeholder)) {
-        console.error("An input component must either have an \"aria-label\" attribute, an \"aria-labelledby\" attribute or a \"placeholder\" attribute.");
-    }
-
     const fluidValue = useResponsiveValue(fluid);
 
     const [inputValue, setValue] = useControllableState(value, defaultValue, "");
@@ -176,6 +172,14 @@ export function InnerTextArea(props: InnerTextAreaProps) {
         type,
         validationState,
         value: inputValue
+    });
+
+    useEffect(() => {
+        const input = inputRef.current;
+
+        if (isNil(ariaLabel) && isNil(ariaLabelledBy) && isNil(placeholder) && isNilOrEmpty(input.labels)) {
+            console.error("An input component must either have a <label> element, a \"aria-label\" attribute, an \"aria-labelledby\" attribute or a \"placeholder\" attribute.");
+        }
     });
 
     const lineHeight = useCalculateLineHeight(inputRef.current);

--- a/packages/components/src/text-area/tests/jest/TextArea.test.tsx
+++ b/packages/components/src/text-area/tests/jest/TextArea.test.tsx
@@ -2,8 +2,13 @@ import { Field, Label } from "@components/field";
 import { act, screen, waitFor, renderWithTheme } from "@test-utils";
 
 import { TextArea } from "@components/text-area";
+import { Text } from "@components/typography";
 import { createRef } from "react";
 import userEvent from "@testing-library/user-event";
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
 
 // ***** Behaviors *****
 
@@ -146,4 +151,54 @@ test("set ref once", async () => {
     );
 
     await waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
+});
+
+
+// ***** Accessibility *****
+
+test("logs an error when label is missing", async () => {
+    const spy = jest.spyOn(console, "error");
+
+    renderWithTheme(<TextArea />);
+
+    expect(spy).toHaveBeenCalled();
+});
+
+test("does not log an error when a label is present", async () => {
+    const spy = jest.spyOn(console, "error");
+
+    renderWithTheme(
+        <Label>
+            Label
+            <TextArea />
+        </Label>
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+
+    renderWithTheme(
+        <>
+            <Label htmlFor="test">Label</Label>
+            <TextArea id="test" />
+        </>
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+
+    renderWithTheme(<TextArea id="test" aria-label="Label" />);
+
+    expect(spy).not.toHaveBeenCalled();
+
+    renderWithTheme(<TextArea id="test" placeholder="Label" />);
+
+    expect(spy).not.toHaveBeenCalled();
+
+    renderWithTheme(
+        <>
+            <Text id="label">Label</Text>
+            <TextArea aria-labelledby="label" />
+        </>
+    );
+
+    expect(spy).not.toHaveBeenCalled();
 });

--- a/packages/components/src/text-input/src/TextInput.tsx
+++ b/packages/components/src/text-input/src/TextInput.tsx
@@ -1,8 +1,8 @@
 import { AbstractInputProps, adaptInputStylingProps, useInput, useInputButton, useInputHasFocus, useInputIcon, useInputSpinner } from "../../input";
 import { Box, BoxProps } from "../../box";
-import { ChangeEvent, ComponentProps, ElementType, ReactElement, forwardRef } from "react";
+import { ChangeEvent, ComponentProps, ElementType, ReactElement, forwardRef, useEffect } from "react";
 import { ClearInputGroupContext, useInputGroupTextInputProps } from "../../input-group";
-import { OmitInternalProps, cssModule, isNil, mergeProps, omitProps, useChainedEventCallback, useControllableState } from "../../shared";
+import { OmitInternalProps, cssModule, isNil, isNilOrEmpty, mergeProps, omitProps, useChainedEventCallback, useControllableState } from "../../shared";
 import { ResponsiveProp, useResponsiveValue } from "../../styling";
 import { useFieldInputProps } from "../../field";
 import { useToolbarProps } from "../../toolbar";
@@ -96,10 +96,6 @@ export function InnerTextInput(props: InnerTextInputProps) {
         ...rest
     } = adaptInputStylingProps(props, contextProps);
 
-    if (isNil(ariaLabel) && isNil(ariaLabelledBy) && isNil(placeholder)) {
-        console.error("An input component must either have an \"aria-label\" attribute, an \"aria-labelledby\" attribute or a \"placeholder\" attribute.");
-    }
-
     const fluidValue = useResponsiveValue(fluid);
 
     const [inputValue, setValue] = useControllableState(value, defaultValue, "");
@@ -114,7 +110,7 @@ export function InnerTextInput(props: InnerTextInputProps) {
         }
     });
 
-    const { inputProps, wrapperProps } = useInput({
+    const { inputProps, inputRef, wrapperProps } = useInput({
         active,
         autoFocus,
         cssModule: "o-ui-text-input",
@@ -132,6 +128,14 @@ export function InnerTextInput(props: InnerTextInputProps) {
         type,
         validationState,
         value: inputValue
+    });
+
+    useEffect(() => {
+        const input = inputRef.current;
+
+        if (isNil(ariaLabel) && isNil(ariaLabelledBy) && isNil(placeholder) && isNilOrEmpty(input.labels)) {
+            console.error("An input component must either have a <label> element, a \"aria-label\" attribute, an \"aria-labelledby\" attribute or a \"placeholder\" attribute.");
+        }
     });
 
     const { hasFocus, inputProps: inputFocusProps } = useInputHasFocus();

--- a/packages/components/src/text-input/tests/jest/TextInput.test.tsx
+++ b/packages/components/src/text-input/tests/jest/TextInput.test.tsx
@@ -4,6 +4,11 @@ import { screen, waitFor, renderWithTheme } from "@test-utils";
 import { TextInput } from "@components/text-input";
 import { createRef } from "react";
 import userEvent from "@testing-library/user-event";
+import { Text } from "@components/typography";
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
 
 test("when a className is provided, render the className on the input element", async () => {
     renderWithTheme(
@@ -187,3 +192,53 @@ test("set ref once", async () => {
 
     await waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
 });
+
+// ***** Accessibility *****
+
+test("logs an error when label is missing", async () => {
+    const spy = jest.spyOn(console, "error");
+
+    renderWithTheme(<TextInput />);
+
+    expect(spy).toHaveBeenCalled();
+});
+
+test("does not log an error when a label is present", async () => {
+    const spy = jest.spyOn(console, "error");
+
+    renderWithTheme(
+        <Label>
+            Label
+            <TextInput />
+        </Label>
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+
+    renderWithTheme(
+        <>
+            <Label htmlFor="test">Label</Label>
+            <TextInput id="test" />
+        </>
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+
+    renderWithTheme(<TextInput id="test" aria-label="Label" />);
+
+    expect(spy).not.toHaveBeenCalled();
+
+    renderWithTheme(<TextInput id="test" placeholder="Label" />);
+
+    expect(spy).not.toHaveBeenCalled();
+
+    renderWithTheme(
+        <>
+            <Text id="label">Label</Text>
+            <TextInput aria-labelledby="label" />
+        </>
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+});
+


### PR DESCRIPTION
<!--
	Thanks for submitting a pull request!

	We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

    Before submitting your pull request, please:
    
    1. Read our contributing documentation: https://github.com/gsoft-inc/sg-orbit/blob/master/CONTRIBUTING.md
    2. Ensure there are no linting or TypeScript errors: `yarn lint`
    3. Verify that tests pass: `yarn jest`
-->

Issue: #1229

## Summary

Removes the warning "An input component must either have a 'aria-label' attribute..." when a `<label>` is present.

## What I did

I moved the validation logic inside a `useEffect` and add a check for `isNilOrEmpty(input.labels)`.

I had to modify `isNilOrEmpty` to support arrays (and NodeList). Instead of checking `value === ""`, it checks `value.length === 0` (this works for strings, arrays and NodeLists).

## How to test

Unit tests were added.
