### PR TITLE
removed use of alias-accent border as it was not available anymore

### DIFF
--- a/docs/features/style-props/StyleProps.stories.mdx
+++ b/docs/features/style-props/StyleProps.stories.mdx
@@ -39,7 +39,7 @@ Props like `border` and `paddingX` are also provided to help you save keystrokes
 ```jsx
 <Div
     paddingY={3}
-    border="alias-accent">
+    border="alias-accent-active">
     Lost in space.
 </Div>
 ```

--- a/docs/features/tokens/TokenTable.jsx
+++ b/docs/features/tokens/TokenTable.jsx
@@ -93,9 +93,9 @@ export function lineHeightRenderer(token) {
 
 export function radiiRenderer(token) {
     if (token === "circular") {
-        return <Div height={4} width={4} borderRadius={token} border="alias-accent"></Div>;
+        return <Div height={4} width={4} borderRadius={token} border="alias-accent-active"></Div>;
     } else {
-        return <Div height={4} width={8} borderRadius={token} border="alias-accent"></Div>;
+        return <Div height={4} width={8} borderRadius={token} border="alias-accent-active"></Div>;
     }
 }
 


### PR DESCRIPTION
Issue: 

## Summary

The documentation of border radius tokens was using a removed token. This have been fixed.
